### PR TITLE
Make accent do more

### DIFF
--- a/platform/brains1/src/Synth.h
+++ b/platform/brains1/src/Synth.h
@@ -199,6 +199,9 @@ void synth_update() {
 
   filter1.frequency((synth.filter/2)+30);
   filter1.resonance(map(synth.resonance,0,1023,70,320)/100.0); // 0.7-3.2 range
+  if(synth.accent) {
+    filter_resonance = 4.0f;
+  }
 
   envelope1.release(((synth.release*synth.release) >> 11)+30);
 

--- a/platform/brains2/libraries/duo-firmware/src/Synth.h
+++ b/platform/brains2/libraries/duo-firmware/src/Synth.h
@@ -179,6 +179,9 @@ void synth_update() {
   float osc_pulse_pulseWidth = map(synth.pulseWidth,0,1023,500,950)/1000.0f;
   float filter_resonance = map(synth.resonance,0,1023,70,320)/100.0f;
   
+  if(synth.accent) {
+    filter_resonance = 4.0f;
+  }
   // Audio interrupts have to be off to apply settings
   AudioNoInterrupts();
 

--- a/platform/brains2/src/duo/boards/DUO_BRAINS_2.1/board_audio_output.h
+++ b/platform/brains2/src/duo/boards/DUO_BRAINS_2.1/board_audio_output.h
@@ -7,8 +7,8 @@ typedef AudioOutputPT8211 BoardAudioOutput;
 
 const float MAIN_GAIN      = 0.8f;
 const float DELAY_GAIN     = 1.0f;
-const float KICK_GAIN      = 2.0f;
-const float HAT_GAIN       = 2.0;
+const float KICK_GAIN      = 1.0f;
+const float HAT_GAIN       = 1.2f;
 
 const float HEADPHONE_GAIN = 1.0f;
 const float SPEAKER_GAIN   = 1.0f;

--- a/platform/brains2/src/duo/boards/DUO_BRAINS_2.1/drums.h
+++ b/platform/brains2/src/duo/boards/DUO_BRAINS_2.1/drums.h
@@ -17,7 +17,7 @@ void init() {
 }
 
 void update() {
-  static unsigned long update_time = millis();
+  static unsigned long update_time;
 
   if(millis() - update_time > 10) {
     update_time = millis();

--- a/platform/brains2/src/duo/boards/DUO_BRAINS_2.1/drums.h
+++ b/platform/brains2/src/duo/boards/DUO_BRAINS_2.1/drums.h
@@ -17,10 +17,10 @@ void init() {
 }
 
 void update() {
-  static unsigned long update_time = millis() + 10;
+  static unsigned long update_time = millis();
 
-  if(millis() > update_time) {
-    update_time = millis() + 10;
+  if(millis() - update_time > 10) {
+    update_time = millis();
     hat_l = pinRead(HAT_PAD_L_PIN);
     hat_m = pinRead(HAT_PAD_M_PIN);
     hat_r = pinRead(HAT_PAD_R_PIN);

--- a/platform/brains2/src/duo/tempo.cpp
+++ b/platform/brains2/src/duo/tempo.cpp
@@ -1,4 +1,4 @@
-#include "lib/tempo.h"
+#include "tempo.h"
 #include <Arduino.h>
 
 #define BPM_TO_MILLIS(bpm) (2500000 / bpm)
@@ -20,10 +20,14 @@ void Tempo::update_internal(TempoHandler &handler, const int potvalue) {
         map(potvalue, 895, 1023, BPM_TO_MILLIS(200), BPM_TO_MILLIS(603));
   }
 
-  const auto cur = millis();
+  const uint32_t cur = millis();
   // Multiply by 100 as a scaling factor for millis_per_beat
   // and a factor of 10 to match original Duo
-  accum += (cur - last_millis) * 1000;
+  // Check if last_millis overflowed since last time.
+  if (cur >= last_millis) {
+    accum += (cur - last_millis) * 1000;
+  }
+
   last_millis = cur;
 
   while (accum >= scaled_millis_per_beat) {

--- a/platform/brains2/src/duo/tempo.cpp
+++ b/platform/brains2/src/duo/tempo.cpp
@@ -1,4 +1,4 @@
-#include "tempo.h"
+#include "lib/tempo.h"
 #include <Arduino.h>
 
 #define BPM_TO_MILLIS(bpm) (2500000 / bpm)


### PR DESCRIPTION
Currently pressing the accent button only opens up the filter a bit more during the attack phase. This change also boosts resonance to 4.0 (which is higher than the normal maximum of 3.2) so that the note is more pronounced regardless of the state of the resonance pot.