### PR TITLE
Refactor main.cpp

### DIFF
--- a/firmware/Pitch.h
+++ b/firmware/Pitch.h
@@ -12,6 +12,7 @@ const uint8_t DETUNE_OFFSET_SEMITONES[] = { 4,5,7,9 };
 int detune_amount = 0;
 uint32_t pitch_update_time = 0;
 void pitch_update();
+float detune(int note, int amount);
 
 // Constant rate glide
 void pitch_update() {

--- a/platform/brains2/src/duo/globals.h
+++ b/platform/brains2/src/duo/globals.h
@@ -43,7 +43,6 @@ uint16_t audio_peak_values = 0UL;
 
 void note_on(uint8_t midi_note, uint8_t velocity, bool enabled);
 void note_off();
-
 void enter_dfu();
 
 #include "firmware/synth_params.h"

--- a/platform/brains2/src/duo/globals.h
+++ b/platform/brains2/src/duo/globals.h
@@ -41,19 +41,8 @@ int random_offset = 0;
 uint32_t midi_clock = 0;
 uint16_t audio_peak_values = 0UL;
 
-void keys_scan();
-void pots_read();
-void drum_init();
-void drum_read();
-void print_log();
-
 void note_on(uint8_t midi_note, uint8_t velocity, bool enabled);
 void note_off();
-
-void keyboard_to_note();
-float detune(int note, int amount);
-
-int tempo_interval_msec();
 
 void enter_dfu();
 

--- a/platform/brains2/src/duo/main.cpp
+++ b/platform/brains2/src/duo/main.cpp
@@ -10,6 +10,8 @@
 #include <Audio.h>
 #include <USB-MIDI.h>
 
+void keys_scan();
+
 unsigned long next_frame_time;
 unsigned int frame_interval = 10;
 

--- a/platform/brains2/src/duo/main.cpp
+++ b/platform/brains2/src/duo/main.cpp
@@ -308,30 +308,7 @@ static void main_loop(){
   }
 }
 
-int main(void) {
-  board_init();
-
-  Sync::init();
-  LEDs::init();
-  pins_init();
-  Drums::init();
-  DatoUSB::init();
-
-  //This is needed to configure the UART peripheral correctly (used for MIDI).
-  Serial.begin(31250U);
-
-  Audio::amp_disable();
-  Audio::headphone_disable();
-  sequencer_init();
-
-  BoardAudioOutput dac1; // xy=988.1000061035156,100
-  AudioAmplifier headphone_preamp;
-  AudioAmplifier speaker_preamp;
-  AudioConnection patchCord16(pop_suppressor, 0, headphone_preamp, 0);
-  AudioConnection patchCord17(pop_suppressor, 0, speaker_preamp, 0);
-  AudioConnection patchCord18(headphone_preamp, 0, dac1, 0);
-  AudioConnection patchCord19(speaker_preamp, 0, dac1, 1);
-
+static void main_init(AudioAmplifier& headphone_preamp, AudioAmplifier& speaker_preamp){
   // Read the MIDI channel from EEPROM. Lowest four bits
   // const uint8_t stored_midi_channel =
   //     eeprom_read_byte(EEPROM_MIDI_CHANNEL) & 0xf00;
@@ -344,6 +321,7 @@ int main(void) {
   // The order sequencer_init, button_matrix_init, led_init and midi_init is
   // important Hold a button of the keyboard at startup to select MIDI channel
   const uint64_t next_frame_time = millis() + 100;
+  sequencer_init();
   button_matrix_init();
   while(millis() < next_frame_time) {
     keys_scan();
@@ -371,7 +349,32 @@ int main(void) {
   Audio::amp_enable();
 
   in_setup = false;
+}
 
+int main(void) {
+  board_init();
+
+  Sync::init();
+  LEDs::init();
+  pins_init();
+  Drums::init();
+  DatoUSB::init();
+
+  //This is needed to configure the UART peripheral correctly (used for MIDI).
+  Serial.begin(31250U);
+
+  Audio::amp_disable();
+  Audio::headphone_disable();
+
+  BoardAudioOutput dac1; // xy=988.1000061035156,100
+  AudioAmplifier headphone_preamp;
+  AudioAmplifier speaker_preamp;
+  AudioConnection patchCord16(pop_suppressor, 0, headphone_preamp, 0);
+  AudioConnection patchCord17(pop_suppressor, 0, speaker_preamp, 0);
+  AudioConnection patchCord18(headphone_preamp, 0, dac1, 0);
+  AudioConnection patchCord19(speaker_preamp, 0, dac1, 1);
+
+  main_init(headphone_preamp, speaker_preamp);
   main_loop();
   return 0;
 }


### PR DESCRIPTION
The goal here is to make `main.cpp` more self-contained, and make most functions `static`.
I believe this can allow the compiler to lay things out better and contribute to less risk of introducing flicker when we do other changes.
It's also another step towards minmizing `globals.h`.