### PR TITLE
Add factory firmware flash mode to updater

### DIFF
--- a/updater/update_firmware.py
+++ b/updater/update_firmware.py
@@ -5,16 +5,16 @@ import sys
 import time
 import rtmidi
 from rtmidi.midiutil import open_midioutput
-from os.path import basename
+from os.path import basename,dirname,abspath
 from spsdk.sdp import SDP
 import spsdk.sdp.interfaces.usb as sdp_usb
 import spsdk.mboot.interfaces.usb as mboot_usb
 from spsdk.mboot import McuBoot
 
-
 def find_duo_midi_port():
     for (index, name) in enumerate(rtmidi.MidiOut().get_ports()):
         if "duo" in name.lower():
+            print(f"Found {name} connected to MIDI")
             return index
     return None
 
@@ -27,6 +27,7 @@ def enter_bootloader():
         return False
     else:
         midiout, portname = open_midioutput(duo_port, use_virtual=False)
+        print(f"Sending reset signal to {portname} at port {duo_port}")
         reset_syx = [0xF0, 0x7d, 0x64, 0x0b, 0xF7]
         midiout.send_message(reset_syx)
         return True
@@ -35,9 +36,10 @@ def enter_bootloader():
 def find_sdp_interface():
     match sdp_usb.scan_usb("0x1FC9,0x0145"):
         case [interface]:
+            print(f"Found {interface.product_name}")
             return interface
         case _:
-            print("No DUO connected")
+            print("No DUO connected in SDP host mode")
             return None
 
 
@@ -46,24 +48,25 @@ def find_mboot_interface():
         case [interface]:
             return interface
         case _:
-            print("No DUO connected")
+            print("No DUO connected in MBOOT mode")
             return None
 
 
-def update_firmware(firmware_path, data_path, continuous):
+def update_firmware(firmware_path, data_path, continuous, skip_enter_bootloader=False):
+    
     with open(firmware_path, "rb") as firmware:
         firmware_bytes = firmware.read()
 
-    if not enter_bootloader():
-        if continuous:
-            print("Continuing. [Continuous mode]")
-        else:
-            input("Please enter bootloader manually, then press Enter.")
+    if not skip_enter_bootloader:
+        if not enter_bootloader():
+            if continuous:
+                print("Continuing. [Continuous mode]")
+            else:
+                input("Please enter bootloader manually, then press Enter.")
+        time.sleep(1)
 
-    time.sleep(1)
     interface = find_sdp_interface()
     if not interface:
-        print("Aborting.")
         return False
 
     print("Sending flashloader")
@@ -76,10 +79,10 @@ def update_firmware(firmware_path, data_path, continuous):
     print("Sent flashloader. Rebooting.")
     time.sleep(1)
 
-    print("Finding boot interface.")
+    print("Finding mboot interface.")
     boot_interface = find_mboot_interface()
     if not boot_interface:
-        print("Aborting.")
+        print("MBoot interface not found.")
         return False
 
     with McuBoot(boot_interface) as mboot:
@@ -91,19 +94,18 @@ def update_firmware(firmware_path, data_path, continuous):
 
         binary_start_addr = 0x60000400
 
-        print("Erasing flash")
+        print("Erasing flash", end=" ")
         mboot.flash_erase_region(binary_start_addr, len(firmware_bytes))
-        print("Done")
+        print("... done")
 
-        print("Writing binary")
+        print(f"Writing binary {basename(firmware_path)}", sep=" ", end=" ")
         mboot.write_memory(binary_start_addr, firmware_bytes)
-        print("Done")
+        print("... done")
 
         print("Resetting")
         mboot.reset(reopen=False)
 
 def main():
-    from os.path import dirname,abspath
     script_path = abspath(dirname(sys.argv[0]))
     data_path = f"{script_path}/data"
 
@@ -113,7 +115,10 @@ def main():
         '-c', '--continuous', action='store_true', 
         help="Disable user interaction and keep polling after successful or failed updates."
     )
-
+    parser.add_argument(
+        '-f', '--factory', action='store_true', 
+        help="Only flash firmware if a blank chip is detected."
+    )
     args = parser.parse_args()
 
     if args.continuous:
@@ -122,9 +127,17 @@ def main():
         while True:
             time.sleep(3)
             update_firmware(args.firmware_path, data_path, True)
+            print()
+    elif args.factory:
+        print("Factory flashing [continuous mode].")
+        print()
+        while True:
+            time.sleep(1)
+            update_firmware(args.firmware_path, data_path, True, True)
+            print()
     else:
         update_firmware(args.firmware_path, data_path, False)
-
+        print()
 
 if __name__ == "__main__":
     main()

--- a/updater/update_firmware.py
+++ b/updater/update_firmware.py
@@ -94,13 +94,13 @@ def update_firmware(firmware_path, data_path, continuous, skip_enter_bootloader=
 
         binary_start_addr = 0x60000400
 
-        print("Erasing flash", end=" ")
+        print("Erasing flash ... ", end=" ")
         mboot.flash_erase_region(binary_start_addr, len(firmware_bytes))
-        print("... done")
+        print("done")
 
-        print(f"Writing binary {basename(firmware_path)}", sep=" ", end=" ")
+        print(f"Writing binary {basename(firmware_path)} ... ", sep=" ", end=" ")
         mboot.write_memory(binary_start_addr, firmware_bytes)
-        print("... done")
+        print("done")
 
         print("Resetting")
         mboot.reset(reopen=False)


### PR DESCRIPTION
This pull request adds a factory firmware flash mode to the updater. It is like continuous mode, but doesn't try to set the DUO to firmware update mode through MIDI.

Reasoning behind this is that you don't want to keep reflashing the Brains while it is plugged in.