### PR TITLE
Embed build information from git as USB string descriptors

### DIFF
--- a/platform/brains2/cmake/add_git_defines.cmake
+++ b/platform/brains2/cmake/add_git_defines.cmake
@@ -36,7 +36,7 @@ execute_process(
 )
 
 if ("${GIT_TAG}" STREQUAL "undefined")
-  SET(GIT_TAG "Development build")
+  SET(GIT_TAG "Dev build")
 endif()
 
 add_definitions("-DGIT_TAG=\"${GIT_TAG}\"")

--- a/platform/brains2/cmake/add_git_defines.cmake
+++ b/platform/brains2/cmake/add_git_defines.cmake
@@ -41,4 +41,4 @@ endif()
 
 add_definitions("-DGIT_TAG=\"${GIT_TAG}\"")
 add_definitions("-DGIT_HASH=\"${GIT_HASH}\"")
-add_definitions("-DGIT_BRANCH=\"${GIT_BRANCH} [${GIT_DIRTY_STATE}]\"")
+add_definitions("-DGIT_BRANCH=\"[${GIT_DIRTY_STATE}] ${GIT_BRANCH}\"")

--- a/platform/brains2/cmake/add_git_defines.cmake
+++ b/platform/brains2/cmake/add_git_defines.cmake
@@ -1,0 +1,44 @@
+execute_process(
+  COMMAND git rev-parse --abbrev-ref HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_BRANCH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+  COMMAND git log -1 --format=%h
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_HASH
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+execute_process(
+  COMMAND git diff --stat
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_DIFF_OUTPUT
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if ("${GIT_DIFF_OUTPUT}" STREQUAL "")
+  SET(GIT_DIRTY_STATE "clean")
+else()
+  SET(GIT_DIRTY_STATE "dirty")
+endif()
+
+
+# Find current tag. If the current commit is not tagged,
+# this command will return "undefined".
+execute_process(
+  COMMAND git name-rev --name-only --tags HEAD
+  WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+  OUTPUT_VARIABLE GIT_TAG
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+
+if ("${GIT_TAG}" STREQUAL "undefined")
+  SET(GIT_TAG "Development build")
+endif()
+
+add_definitions("-DGIT_TAG=\"${GIT_TAG}\"")
+add_definitions("-DGIT_HASH=\"${GIT_HASH}\"")
+add_definitions("-DGIT_BRANCH=\"${GIT_BRANCH} [${GIT_DIRTY_STATE}]\"")

--- a/platform/brains2/cmake/build_app.cmake
+++ b/platform/brains2/cmake/build_app.cmake
@@ -15,6 +15,7 @@ include(${COMMON_CMAKE}/modules.cmake)
 include(${COMMON_CMAKE}/lib.cmake)
 
 if(WITH_USB)
+  include(${COMMON_CMAKE}/add_git_defines.cmake)
   include(${COMMON_CMAKE}/usb.cmake)
 endif(WITH_USB)
 

--- a/platform/brains2/src/CMakeLists.txt
+++ b/platform/brains2/src/CMakeLists.txt
@@ -30,4 +30,3 @@ target_include_directories(${EXECUTABLE_NAME} PRIVATE
 set(WITH_USB true)
 include(${CMAKE_CURRENT_SOURCE_DIR}/../cmake/build_app.cmake)
 
-

--- a/platform/brains2/src/lib/usb/usb_descriptors.c
+++ b/platform/brains2/src/lib/usb/usb_descriptors.c
@@ -100,7 +100,7 @@ char const *string_desc_arr[7] = {
     GIT_BRANCH,
     GIT_HASH};
 
-#define DESC_STR_LEN 128
+#define DESC_STR_LEN 32
 static uint16_t _desc_str[DESC_STR_LEN];
 
 // Invoked when received GET STRING DESCRIPTOR request

--- a/platform/brains2/src/lib/usb/usb_descriptors.c
+++ b/platform/brains2/src/lib/usb/usb_descriptors.c
@@ -91,13 +91,17 @@ uint8_t const *tud_descriptor_configuration_cb(uint8_t index) {
 //--------------------------------------------------------------------+
 
 // array of pointer to string descriptors
-char const *string_desc_arr[3] = {
+char const *string_desc_arr[7] = {
     (const char[]){0x09, 0x04}, // 0: is supported language is English (0x0409)
     "Dato",                     // 1: Manufacturer
-    "Dato DUO"                  // 2: Product
-};
+    "Dato DUO",                 // 2: Product
+    NULL,                       // 3: Serial. Built upon request.
+    GIT_TAG,
+    GIT_BRANCH,
+    GIT_HASH};
 
-static uint16_t _desc_str[32];
+#define DESC_STR_LEN 128
+static uint16_t _desc_str[DESC_STR_LEN];
 
 // Invoked when received GET STRING DESCRIPTOR request
 // Application return pointer to descriptor, whose contents must exist long
@@ -116,8 +120,8 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
     const uint32_t ID_1 = OCOTP->CFG1;
     char tmp_serial[32];
     chr_count = snprintf(tmp_serial, sizeof(tmp_serial), "%li-%li", ID_0, ID_1);
-    if (chr_count > 31) {
-      chr_count = 31;
+    if (chr_count > DESC_STR_LEN-1) {
+      chr_count = DESC_STR_LEN-1;
     }
 
     for (uint8_t i = 0; i < chr_count; i++) {
@@ -135,8 +139,8 @@ uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
 
     // Cap at max char
     chr_count = strlen(str);
-    if (chr_count > 31)
-      chr_count = 31;
+    if (chr_count > DESC_STR_LEN-1)
+      chr_count = DESC_STR_LEN-1;
 
     // Convert ASCII string into UTF-16
     for (uint8_t i = 0; i < chr_count; i++) {

--- a/updater/firmware_info.py
+++ b/updater/firmware_info.py
@@ -1,0 +1,23 @@
+import usb
+from typing import NamedTuple
+
+class FirmwareInfo(NamedTuple):
+    tag: str
+    branch: str
+    commit: str
+
+def get_firmware_info():
+    dev = usb.core.find(idVendor=0x16d0, idProduct=0x10a7)
+    if dev is None:
+        print('No DUO connected.')
+        return None
+    else:
+        return FirmwareInfo(
+                tag = usb.util.get_string(dev, 4),
+                branch = usb.util.get_string(dev, 5),
+                commit = usb.util.get_string(dev, 6))
+
+if __name__ == "__main__":
+    info = get_firmware_info()
+    for k, v in info._asdict().items():
+        print(f"{k}: {v}")

--- a/updater/requirements.txt
+++ b/updater/requirements.txt
@@ -1,2 +1,3 @@
 python-rtmidi==1.5.0
 spsdk==1.8.0
+pyusb


### PR DESCRIPTION
Adds a CMake script which generates defines based on git information of the current branch.
This is used by `usb_descriptors.c` to present through USB string descriptors.
Also adds a small python script to query the relevant string descriptors.