### PR TITLE
Lower power sleep

### DIFF
--- a/platform/brains2/src/duo/main.cpp
+++ b/platform/brains2/src/duo/main.cpp
@@ -135,7 +135,7 @@ static void pots_read() {
   synth.delay = pinRead(DELAY_PIN);
 }
 
-static inline void power_off() {
+static void power_off() {
   // Stop sequencer
   MIDI.sendControlChange(123,0,MIDI_CHANNEL);
   AudioNoInterrupts();

--- a/platform/brains2/src/duo/main.cpp
+++ b/platform/brains2/src/duo/main.cpp
@@ -327,6 +327,9 @@ static void main_loop(){
         keys_scan(); // 14 or 175us (depending on debounce)
       }
     } else {
+      AudioNoInterrupts();
+      Audio::amp_disable();
+      Audio::headphone_disable();
       if(keys_scan_powerbutton()) { 
         NVIC_SystemReset();
       }

--- a/platform/brains2/src/duo/main.cpp
+++ b/platform/brains2/src/duo/main.cpp
@@ -72,6 +72,9 @@ const int led_order[NUM_LEDS] = {1,  2,  3,  4,  5,  6,  7,  8,  9,  10,
 #include "duo-firmware/src/DrumSynth.h"
 #include "drums.h"
 
+// TODO: make this not global. Needed for dac1.stop()
+BoardAudioOutput dac1; // xy=988.1000061035156,100
+
 void note_on(uint8_t midi_note, uint8_t velocity, bool enabled) {
   // Override velocity if button on the synth is pressed
   if (synth.accent) {
@@ -132,7 +135,7 @@ static void pots_read() {
   synth.delay = pinRead(DELAY_PIN);
 }
 
-static void power_off() {
+static inline void power_off() {
   // Stop sequencer
   MIDI.sendControlChange(123,0,MIDI_CHANNEL);
   AudioNoInterrupts();
@@ -141,7 +144,9 @@ static void power_off() {
   // turn off audio
   Audio::amp_disable();
   Audio::headphone_disable();
+
   // turn off leds
+  dac1.stop();
   // de-enumerate usb (?)
   DatoUSB::disconnect(); 
   led_deinit();
@@ -303,11 +308,8 @@ static void headphone_jack_check() {
 static void main_loop(){
   static unsigned long frame_time = millis();
   static unsigned long frame_interval = 11;
-  bool pinState = LOW;
-  while (true) {
-    digitalWrite(GPIO_SD_13, pinState);
-    pinState = !pinState;
 
+  while (true) {
     if (is_power_on()) {
       if (millis() - frame_time > frame_interval) {
         frame_time = millis();
@@ -327,12 +329,12 @@ static void main_loop(){
         keys_scan(); // 14 or 175us (depending on debounce)
       }
     } else {
-      AudioNoInterrupts();
-      Audio::amp_disable();
-      Audio::headphone_disable();
-      if(keys_scan_powerbutton()) { 
-        NVIC_SystemReset();
-      }
+      if (millis() - frame_time > frame_interval) {
+        frame_time = millis();
+        if(keys_scan_powerbutton()) { 
+          NVIC_SystemReset();
+        }
+      } 
     }
   }
 }
@@ -396,7 +398,6 @@ int main(void) {
   Audio::amp_disable();
   Audio::headphone_disable();
 
-  BoardAudioOutput dac1; // xy=988.1000061035156,100
   AudioAmplifier headphone_preamp;
   AudioAmplifier speaker_preamp;
   AudioConnection patchCord16(pop_suppressor, 0, headphone_preamp, 0);

--- a/platform/brains2/src/duo/main.cpp
+++ b/platform/brains2/src/duo/main.cpp
@@ -406,6 +406,7 @@ int main(void) {
   AudioConnection patchCord19(speaker_preamp, 0, dac1, 1);
 
   main_init(headphone_preamp, speaker_preamp);
+  dac1.begin();
   main_loop();
   return 0;
 }

--- a/platform/brains2/src/lib/custom_teensy_audio/output_mqs.cpp
+++ b/platform/brains2/src/lib/custom_teensy_audio/output_mqs.cpp
@@ -150,6 +150,9 @@ void AudioOutputMQS::begin(void) {
   SAI_TransferSendEDMA(SAI, &tx_handle, &xfer);
 }
 
+void AudioOutputMQS::stop(void) {
+  SAI_Deinit(SAI);
+}
 /*
  * buffer_toggle:
  *  Track which half of the audio buffer we're filling.

--- a/platform/brains2/src/lib/custom_teensy_audio/output_mqs.h
+++ b/platform/brains2/src/lib/custom_teensy_audio/output_mqs.h
@@ -42,6 +42,7 @@ public:
 	AudioOutputMQS(void) : AudioStream(2, inputQueueArray) { begin(); }
 	virtual void update(void);
 	void begin(void);
+	void stop(void);
 	friend class AudioInputI2S2;
 protected:
 	static audio_block_t *block_left_1st;

--- a/platform/brains2/src/lib/custom_teensy_audio/output_pt8211.h
+++ b/platform/brains2/src/lib/custom_teensy_audio/output_pt8211.h
@@ -52,6 +52,7 @@ public:
 	AudioOutputPT8211(void) : AudioStream(2, inputQueueArray) { begin(); }
 	virtual void update(void);
 	void begin(void);
+	void stop(void);
 protected:
 	static void config_i2s(void);
 	static audio_block_t *block_left_1st;


### PR DESCRIPTION
This branch sleeps at under 100mA. 

1. turns off audio and headphone amp
2. turns off clock to DAC
3. slows down powerbutton scanning

More could be done by clocking down the processor or switching to one of the real low power states but < 100mA seems good for now.