### PR TITLE
Quantize on quarter of step time

### DIFF
--- a/firmware/seq.cpp
+++ b/firmware/seq.cpp
@@ -25,7 +25,6 @@ static uint8_t divider_from_speed_mod(const SpeedModifier mod) {
 
 static Zone get_zone(uint32_t clock, const SpeedModifier speed_mod) {
   const uint32_t ticks = divider_from_speed_mod(speed_mod);
-  const uint32_t third = ticks / 3;
   const uint32_t fourth = ticks / 4;
   clock = clock % ticks;
 

--- a/firmware/seq.cpp
+++ b/firmware/seq.cpp
@@ -26,11 +26,12 @@ static uint8_t divider_from_speed_mod(const SpeedModifier mod) {
 static Zone get_zone(uint32_t clock, const SpeedModifier speed_mod) {
   const uint32_t ticks = divider_from_speed_mod(speed_mod);
   const uint32_t third = ticks / 3;
+  const uint32_t fourth = ticks / 4;
   clock = clock % ticks;
 
-  if (clock <= third) {
+  if (clock <= fourth) {
     return Early;
-  } else if (clock >= 2 * third) {
+  } else if (clock >= 3 * fourth) {
     return Late;
   } else {
     return Middle;


### PR DESCRIPTION
This changes the quantization window to a quarter of the step length before and after the step boundary. In the middle half of the step a note is only played but not stored.