### PR TITLE
SYNC in based on pin interrupt

### DIFF
--- a/platform/brains2/src/lib/sync.cpp
+++ b/platform/brains2/src/lib/sync.cpp
@@ -11,6 +11,8 @@
 
 
 namespace Sync {
+    uint32_t syncPinState;
+
     void handleSyncInterrupt(void) {
       GPIO_PortClearInterruptFlags(SYNC_IN_PORT, 1U << SYNC_IN_PIN);
       Sync::syncPinState = 1;

--- a/platform/brains2/src/lib/sync.cpp
+++ b/platform/brains2/src/lib/sync.cpp
@@ -3,12 +3,29 @@
 #include "fsl_iomuxc.h"
 #include "board.h"
 #include "duo/pins.h"
+#include <Arduino.h>
+
+#define SYNC_NVIC_PRIORITY 150
+#define SYNC_PIN_IRQ GPIO1_Combined_0_15_IRQn
+#define SYNC_PIN_IRQ_HANDLER GPIO1_Combined_0_15_IRQHandler
+
 
 namespace Sync {
+    void handleSyncInterrupt(void) {
+      GPIO_PortClearInterruptFlags(SYNC_IN_PORT, 1U << SYNC_IN_PIN);
+      Sync::syncPinState = 1;
+    }
+
     void init() {
         IOMUXC_SetPinMux(SYNC_IN_PINMUX, 0U);
         gpio_pin_config_t sync_in_config = { kGPIO_DigitalInput, 0, kGPIO_IntRisingEdge};
+        GPIO_SetPinInterruptConfig(SYNC_IN_PORT, SYNC_IN_PIN, kGPIO_IntFallingEdge);
+        NVIC_SetPriority(SYNC_PIN_IRQ, SYNC_NVIC_PRIORITY);
+        NVIC_SetVector(SYNC_PIN_IRQ, (uint32_t)&Sync::handleSyncInterrupt);
+        EnableIRQ(SYNC_PIN_IRQ);
         GPIO_PinInit(SYNC_IN_PORT, SYNC_IN_PIN, &sync_in_config);
+        GPIO_PortClearInterruptFlags(SYNC_IN_PORT, 1 << SYNC_IN_PIN);
+        GPIO_PortEnableInterrupts(SYNC_IN_PORT, 1 << SYNC_IN_PIN);
 
         IOMUXC_SetPinMux(SYNC_OUT_PINMUX, 0U);
         gpio_pin_config_t sync_out_config = { kGPIO_DigitalOutput, 0};
@@ -16,7 +33,11 @@ namespace Sync {
     }
 
     uint32_t read() {
-        return GPIO_PinRead(SYNC_IN_PORT, SYNC_IN_PIN);
+       if(syncPinState == 1) {
+         syncPinState = 0;
+         return HIGH;
+      }
+      return LOW;
     }
     
     void write(uint8_t value) {

--- a/platform/brains2/src/lib/sync.h
+++ b/platform/brains2/src/lib/sync.h
@@ -4,9 +4,7 @@
 
 namespace Sync {
     void init();
-    bool jackDetected();
     uint32_t read();
     void write(uint8_t value);
     bool detect();
-    uint32_t syncPinState;
 }

--- a/platform/brains2/src/lib/sync.h
+++ b/platform/brains2/src/lib/sync.h
@@ -8,4 +8,5 @@ namespace Sync {
     uint32_t read();
     void write(uint8_t value);
     bool detect();
+    uint32_t syncPinState;
 }

--- a/updater/requirements.txt
+++ b/updater/requirements.txt
@@ -1,3 +1,3 @@
-python-rtmidi==1.5.0
-spsdk==1.8.0
+python-rtmidi
+spsdk
 pyusb

--- a/updater/requirements.txt
+++ b/updater/requirements.txt
@@ -1,3 +1,3 @@
-python-rtmidi
-spsdk
+python-rtmidi=1.5.6
+spsdk=2.0.0
 pyusb


### PR DESCRIPTION
Fixes https://github.com/datomusic/duo-imxrt/issues/147 by using a GPIO interrupt to handle sync in.