### PR TITLE
Align sync pulses on sequencer reset

### DIFF
--- a/firmware/Sequencer.h
+++ b/firmware/Sequencer.h
@@ -45,23 +45,25 @@ void sequencer_stop() {
     MIDI.sendRealTime(midi::Stop);
   }
 
-  sequencer.stop();
+  sequencer.set_running(false);
 }
 
-void sequencer_start() {
-  MIDI.sendRealTime(midi::Continue);
-  usbMIDI.sendRealTime(midi::Continue);
-  sequencer.start();
+void sequencer_start(const enum midi::MidiType midi_message) {
+  MIDI.sendRealTime(midi_message);
+  usbMIDI.sendRealTime(midi_message);
+
   if (tempo_handler.is_clock_source_internal()) {
-    tempo_handler.reset_clock_source();
+    tempo_handler.reset_tempo();
   }
+  sequencer.reset();
+  sequencer.set_running(true);
 }
 
 void sequencer_toggle_start() {
   if (sequencer.is_running()) {
     sequencer_stop();
   } else {
-    sequencer_start();
+    sequencer_start(midi::Continue);
   }
 }
 
@@ -87,9 +89,7 @@ static void sequencer_init() {
 }
 
 void sequencer_restart() {
-  MIDI.sendRealTime(midi::Start);
-  delay(1);
-  sequencer.restart();
+  sequencer_start(midi::Start);
 }
 
 #define keyboard_set_note(note) sequencer.hold_note(note)

--- a/firmware/Sequencer.h
+++ b/firmware/Sequencer.h
@@ -61,6 +61,7 @@ void sequencer_start() {
 void sequencer_start_from_MIDI() {
   MIDI.sendRealTime(midi::Start);
   usbMIDI.sendRealTime(midi::Start);
+  delay(1);
   tempo_handler.set_MIDI_source();
   sequencer.run();
 }

--- a/firmware/Sequencer.h
+++ b/firmware/Sequencer.h
@@ -26,9 +26,7 @@ void sequencer_update() {
   sequencer.speed_mod = (Sequencer::SpeedModifier)speed_mod;
 
   sequencer.set_gate_length(map(synth.gateLength, 0, 1023, 10, 200) * 1000);
-  if (sequencer.is_running()) {
-    tempo_handler.update(synth.speed);
-  }
+  tempo_handler.update(synth.speed);
 
   const uint32_t cur_micros = micros();
   const uint32_t delta = cur_micros - last_sequencer_update;
@@ -51,13 +49,6 @@ void sequencer_start() {
   MIDI.sendRealTime(midi::Continue);
   usbMIDI.sendRealTime(midi::Continue);
   sequencer.start();
-  if(tempo_handler.is_clock_source_internal()){
-    tempo_handler.reset_clock_source();
-    for (int i = 0; i < 12; i++) {
-      tempo_handler.update(synth.speed);
-    }
-    /* sequencer_update(); */
-  }
 }
 
 void sequencer_toggle_start() {

--- a/firmware/Sequencer.h
+++ b/firmware/Sequencer.h
@@ -5,6 +5,8 @@
  Note timing is divided into 24 steps per quarter note
  */
 
+#include <cstdint>
+
 uint32_t last_sequencer_update;
 bool double_speed = false;
 
@@ -56,6 +58,13 @@ void sequencer_start() {
   sequencer.run();
 }
 
+void sequencer_start_from_MIDI() {
+  MIDI.sendRealTime(midi::Start);
+  usbMIDI.sendRealTime(midi::Start);
+  tempo_handler.set_MIDI_source();
+  sequencer.run();
+}
+
 void sequencer_toggle_start() {
   if (sequencer.is_running()) {
     sequencer_stop();
@@ -83,13 +92,6 @@ static void sequencer_init() {
 
   sequencer_stop();
   double_speed = false;
-}
-
-void sequencer_restart() {
-  MIDI.sendRealTime(midi::Start);
-  usbMIDI.sendRealTime(midi::Start);
-  delay(1);
-  sequencer.run();
 }
 
 #define keyboard_set_note(note) sequencer.hold_note(note)

--- a/firmware/Sequencer.h
+++ b/firmware/Sequencer.h
@@ -88,6 +88,7 @@ static void sequencer_init() {
 
 void sequencer_restart() {
   MIDI.sendRealTime(midi::Start);
+  usbMIDI.sendRealTime(midi::Start);
   delay(1);
   sequencer.reset_playback();
   sequencer.set_running(true);

--- a/firmware/Sequencer.h
+++ b/firmware/Sequencer.h
@@ -5,6 +5,9 @@
  Note timing is divided into 24 steps per quarter note
  */
 
+#include "seq.h"
+#include <cstdint>
+
 uint32_t last_sequencer_update;
 bool double_speed = false;
 
@@ -49,6 +52,9 @@ void sequencer_start() {
   MIDI.sendRealTime(midi::Continue);
   usbMIDI.sendRealTime(midi::Continue);
   sequencer.start();
+  if (tempo_handler.is_clock_source_internal()) {
+    tempo_handler.reset_clock_source();
+  }
 }
 
 void sequencer_toggle_start() {
@@ -62,7 +68,6 @@ void sequencer_toggle_start() {
 static void sequencer_tick_clock() {
   sequencer.tick_clock();
 }
-
 
 static void sequencer_align_clock() {
   sequencer.align_clock();

--- a/firmware/Sequencer.h
+++ b/firmware/Sequencer.h
@@ -26,7 +26,9 @@ void sequencer_update() {
   sequencer.speed_mod = (Sequencer::SpeedModifier)speed_mod;
 
   sequencer.set_gate_length(map(synth.gateLength, 0, 1023, 10, 200) * 1000);
-  tempo_handler.update(synth.speed);
+  if (sequencer.is_running()) {
+    tempo_handler.update(synth.speed);
+  }
 
   const uint32_t cur_micros = micros();
   const uint32_t delta = cur_micros - last_sequencer_update;
@@ -49,6 +51,13 @@ void sequencer_start() {
   MIDI.sendRealTime(midi::Continue);
   usbMIDI.sendRealTime(midi::Continue);
   sequencer.start();
+  if(tempo_handler.is_clock_source_internal()){
+    tempo_handler.reset_clock_source();
+    for (int i = 0; i < 12; i++) {
+      tempo_handler.update(synth.speed);
+    }
+    /* sequencer_update(); */
+  }
 }
 
 void sequencer_toggle_start() {

--- a/firmware/Sequencer.h
+++ b/firmware/Sequencer.h
@@ -55,7 +55,7 @@ void sequencer_start(const enum midi::MidiType midi_message) {
   if (tempo_handler.is_clock_source_internal()) {
     tempo_handler.reset_tempo();
   }
-  sequencer.reset();
+  sequencer.reset_playback();
   sequencer.set_running(true);
 }
 

--- a/firmware/Sequencer.h
+++ b/firmware/Sequencer.h
@@ -5,9 +5,6 @@
  Note timing is divided into 24 steps per quarter note
  */
 
-#include "seq.h"
-#include <cstdint>
-
 uint32_t last_sequencer_update;
 bool double_speed = false;
 
@@ -48,13 +45,14 @@ void sequencer_stop() {
   sequencer.set_running(false);
 }
 
-void sequencer_start(const enum midi::MidiType midi_message) {
-  MIDI.sendRealTime(midi_message);
-  usbMIDI.sendRealTime(midi_message);
+void sequencer_start() {
+  MIDI.sendRealTime(midi::Continue);
+  usbMIDI.sendRealTime(midi::Continue);
 
   if (tempo_handler.is_clock_source_internal()) {
     tempo_handler.reset_tempo();
   }
+
   sequencer.reset_playback();
   sequencer.set_running(true);
 }
@@ -63,7 +61,7 @@ void sequencer_toggle_start() {
   if (sequencer.is_running()) {
     sequencer_stop();
   } else {
-    sequencer_start(midi::Continue);
+    sequencer_start();
   }
 }
 
@@ -89,7 +87,10 @@ static void sequencer_init() {
 }
 
 void sequencer_restart() {
-  sequencer_start(midi::Start);
+  MIDI.sendRealTime(midi::Start);
+  delay(1);
+  sequencer.reset_playback();
+  sequencer.set_running(true);
 }
 
 #define keyboard_set_note(note) sequencer.hold_note(note)

--- a/firmware/Sequencer.h
+++ b/firmware/Sequencer.h
@@ -42,7 +42,7 @@ void sequencer_stop() {
     MIDI.sendRealTime(midi::Stop);
   }
 
-  sequencer.set_running(false);
+  sequencer.stop();
 }
 
 void sequencer_start() {
@@ -54,7 +54,7 @@ void sequencer_start() {
   }
 
   sequencer.reset_playback();
-  sequencer.set_running(true);
+  sequencer.run();
 }
 
 void sequencer_toggle_start() {
@@ -91,7 +91,7 @@ void sequencer_restart() {
   usbMIDI.sendRealTime(midi::Start);
   delay(1);
   sequencer.reset_playback();
-  sequencer.set_running(true);
+  sequencer.run();
 }
 
 #define keyboard_set_note(note) sequencer.hold_note(note)

--- a/firmware/Sequencer.h
+++ b/firmware/Sequencer.h
@@ -53,7 +53,6 @@ void sequencer_start() {
     tempo_handler.reset_tempo();
   }
 
-  sequencer.reset_playback();
   sequencer.run();
 }
 
@@ -90,7 +89,6 @@ void sequencer_restart() {
   MIDI.sendRealTime(midi::Start);
   usbMIDI.sendRealTime(midi::Start);
   delay(1);
-  sequencer.reset_playback();
   sequencer.run();
 }
 

--- a/firmware/TempoHandler.h
+++ b/firmware/TempoHandler.h
@@ -20,146 +20,149 @@
 #ifndef TempoHandler_h
 #define TempoHandler_h
 
-#define TEMPO_SYNC_DIVIDER   (Sequencer::PULSES_PER_QUARTER_NOTE / 2)
+#define TEMPO_SYNC_DIVIDER (Sequencer::PULSES_PER_QUARTER_NOTE / 2)
 
-#include <MIDI.h>
-#include "lib/tempo.h"
-#include "lib/sync.h"
-#include "firmware/seq.h"
 #include "lib/elapsedMillis.h"
+#include "lib/sync.h"
+#include "lib/tempo.h"
+#include "seq.h"
+#include <MIDI.h>
+#include <stdint.h>
 
 void midi_send_realtime(const midi::MidiType message);
- 
-class TempoHandler 
-{
+
+class TempoHandler {
   friend class Tempo;
 
-  public:
-    TempoHandler() {
-      tempo.reset();
+public:
+  TempoHandler() {
+    tempo.reset();
+  }
+
+  inline void setHandleTempoEvent(void (*fptr)()) {
+    tTempoCallback = fptr;
+  }
+
+  inline void setHandleAlignEvent(void (*fptr)()) {
+    tAlignCallback = fptr;
+  }
+
+  void update(const uint32_t synth_speed) {
+    if (_source != TEMPO_SOURCE_SYNC && Sync::detect()) {
+      _source = TEMPO_SOURCE_SYNC;
     }
 
-    inline void setHandleTempoEvent(void (*fptr)()) {
-      tTempoCallback = fptr;
-    }
-    inline void setHandleAlignEvent(void (*fptr)()) {
-      tAlignCallback = fptr;
-    }
-    void update(const uint32_t synth_speed) {
-      if(_source != TEMPO_SOURCE_SYNC && Sync::detect()){
-        _source = TEMPO_SOURCE_SYNC;
-      }
-
-      switch(_source) {
-        case TEMPO_SOURCE_INTERNAL:
-          tempo.update_internal(*this, synth_speed);
-          break;
-        case TEMPO_SOURCE_SYNC:
-          update_sync();
-          break;
-        case TEMPO_SOURCE_MIDI:
-          break;
-      }
-
-      if(syncStart >= TEMPO_SYNC_DIVIDER) {
-        Sync::write(LOW);
-      }
+    switch (_source) {
+    case TEMPO_SOURCE_INTERNAL:
+      tempo.update_internal(*this, synth_speed);
+      break;
+    case TEMPO_SOURCE_SYNC:
+      update_sync();
+      break;
+    case TEMPO_SOURCE_MIDI:
+      break;
     }
 
-    void midi_clock_received() {
-      if (_source != TEMPO_SOURCE_MIDI) {
-        _source = TEMPO_SOURCE_MIDI;
-      }
-
-      _previous_clock_time = micros();
-      trigger();
+    if (syncStart >= TEMPO_SYNC_DIVIDER) {
+      Sync::write(LOW);
     }
-    void reset_clock_source() {
-      _source = TEMPO_SOURCE_INTERNAL;
-      tempo.reset();
-      reset_clock();
+  }
+
+  void midi_clock_received() {
+    if (_source != TEMPO_SOURCE_MIDI) {
+      _source = TEMPO_SOURCE_MIDI;
     }
-    bool is_clock_source_internal() const {
-      return _source == TEMPO_SOURCE_INTERNAL;
+
+    _previous_clock_time = micros();
+    trigger();
+  }
+
+  void reset_clock_source() {
+    _source = TEMPO_SOURCE_INTERNAL;
+    tempo.reset();
+    reset_clock();
+  }
+
+  bool is_clock_source_internal() const {
+    return _source == TEMPO_SOURCE_INTERNAL;
+  }
+
+private:
+  enum Source {
+    TEMPO_SOURCE_MIDI,
+    TEMPO_SOURCE_SYNC,
+    TEMPO_SOURCE_INTERNAL
+  };
+
+  Tempo tempo;
+  elapsedMillis syncStart;
+  void (*tTempoCallback)();
+  void (*tAlignCallback)();
+  Source _source = TEMPO_SOURCE_INTERNAL;
+  uint32_t _previous_clock_time = 0;
+  uint32_t _previous_sync_time = 0;
+  uint32_t _tempo_interval = 0;
+  uint16_t _clock = 0;
+
+  void reset_clock() {
+    _previous_clock_time = micros();
+    _clock = 0;
+  }
+
+  void update_sync() {
+    if (!Sync::detect()) {
+      reset_clock_source();
+      return;
     }
-  private:
 
-    enum Source{
-      TEMPO_SOURCE_MIDI,
-      TEMPO_SOURCE_SYNC,
-      TEMPO_SOURCE_INTERNAL
-    };
+    static uint8_t _sync_pin_previous_value = 1;
+    const uint8_t _sync_pin_value = Sync::read();
 
-
-    Tempo tempo;
-    elapsedMillis syncStart;
-    void (*tTempoCallback)();
-    void (*tAlignCallback)();
-    Source _source = TEMPO_SOURCE_INTERNAL;
-    uint32_t _previous_clock_time = 0;
-    uint32_t _previous_sync_time = 0;
-    uint32_t _tempo_interval = 0;
-    uint16_t _clock = 0;
-
-    void reset_clock(){
-      _previous_clock_time = micros();
+    if (_sync_pin_previous_value && !_sync_pin_value) {
+      _tempo_interval = (micros() - _previous_sync_time) / TEMPO_SYNC_DIVIDER;
       _clock = 0;
-    }
-
-    void update_sync() {
-      if (!Sync::detect()) {
-        reset_clock_source();
-        return;
+      _previous_sync_time = micros();
+      _previous_clock_time = micros();
+      if (tAlignCallback != 0) {
+        tAlignCallback();
       }
-
-      static uint8_t _sync_pin_previous_value = 1;
-      const uint8_t _sync_pin_value = Sync::read();
-
-      if(_sync_pin_previous_value && !_sync_pin_value) {
-        _tempo_interval = (micros() - _previous_sync_time) / TEMPO_SYNC_DIVIDER;
-        _clock = 0;
-        _previous_sync_time = micros();
-        _previous_clock_time = micros();
-        if (tAlignCallback != 0) {
-          tAlignCallback();
-        }
-        if (tTempoCallback != 0) {
-          trigger();
-        }
-      } else {
-        if(micros() - _previous_clock_time > _tempo_interval) {
-          if(_clock < TEMPO_SYNC_DIVIDER) {
-            if (tTempoCallback != 0) {
-              _previous_clock_time = micros();
-              trigger();
-            }
+      if (tTempoCallback != 0) {
+        trigger();
+      }
+    } else {
+      if (micros() - _previous_clock_time > _tempo_interval) {
+        if (_clock < TEMPO_SYNC_DIVIDER) {
+          if (tTempoCallback != 0) {
+            _previous_clock_time = micros();
+            trigger();
           }
         }
       }
-      _sync_pin_previous_value = _sync_pin_value;
     }
+    _sync_pin_previous_value = _sync_pin_value;
+  }
 
-    /*
-     * Calls the callback, updates the clock and sends out MIDI/Sync pulses
-     */
-    void trigger() {
-      midi_send_realtime(midi::Clock);
+  /*
+   * Calls the callback, updates the clock and sends out MIDI/Sync pulses
+   */
+  void trigger() {
+    midi_send_realtime(midi::Clock);
 
-      if((_clock % Sequencer::PULSES_PER_QUARTER_NOTE) == 0) {
-        _clock = 0;
-      }
-      if((_clock % TEMPO_SYNC_DIVIDER) == 0) {
-        Sync::write(HIGH);
-        syncStart = 0;
-      } 
-      if (tTempoCallback != 0) {
-        tTempoCallback();
-      }
-      if (_source == TEMPO_SOURCE_MIDI) {
-        _previous_clock_time = micros();
-      }
-      _clock++;
+    if ((_clock % Sequencer::PULSES_PER_QUARTER_NOTE) == 0) {
+      _clock = 0;
     }
+    if ((_clock % TEMPO_SYNC_DIVIDER) == 0) {
+      Sync::write(HIGH);
+      syncStart = 0;
+    }
+    if (tTempoCallback != 0) {
+      tTempoCallback();
+    }
+    if (_source == TEMPO_SOURCE_MIDI) {
+      _previous_clock_time = micros();
+    }
+    _clock++;
+  }
 };
 
 #endif

--- a/firmware/TempoHandler.h
+++ b/firmware/TempoHandler.h
@@ -76,10 +76,12 @@ class TempoHandler
     }
     void reset_clock_source() {
       _source = TEMPO_SOURCE_INTERNAL;
+      reset_tempo();
+    }
+    void reset_tempo(){
       tempo.reset();
       _previous_clock_time = micros();
       _clock = 0;
-      trigger();
     }
     bool is_clock_source_internal() const {
       return _source == TEMPO_SOURCE_INTERNAL;

--- a/firmware/TempoHandler.h
+++ b/firmware/TempoHandler.h
@@ -20,146 +20,143 @@
 #ifndef TempoHandler_h
 #define TempoHandler_h
 
-#define TEMPO_SYNC_DIVIDER (Sequencer::PULSES_PER_QUARTER_NOTE / 2)
+#define TEMPO_SYNC_DIVIDER   (Sequencer::PULSES_PER_QUARTER_NOTE / 2)
 
-#include "lib/elapsedMillis.h"
-#include "lib/sync.h"
-#include "lib/tempo.h"
-#include "seq.h"
 #include <MIDI.h>
-#include <cstdint>
+#include "lib/tempo.h"
+#include "lib/sync.h"
+#include "firmware/seq.h"
+#include "lib/elapsedMillis.h"
 
 void midi_send_realtime(const midi::MidiType message);
+ 
+class TempoHandler 
+{
+  friend class Tempo;
 
-class TempoHandler {
-  friend struct Tempo;
-
-public:
-  TempoHandler() {
-    tempo.reset();
-  }
-
-  inline void setHandleTempoEvent(void (*fptr)()) {
-    tTempoCallback = fptr;
-  }
-
-  inline void setHandleAlignEvent(void (*fptr)()) {
-    tAlignCallback = fptr;
-  }
-
-  void update(const uint32_t synth_speed) {
-    if (_source != TEMPO_SOURCE_SYNC && Sync::detect()) {
-      _source = TEMPO_SOURCE_SYNC;
+  public:
+    TempoHandler() {
+      tempo.reset();
     }
 
-    switch (_source) {
-    case TEMPO_SOURCE_INTERNAL:
-      tempo.update_internal(*this, synth_speed);
-      break;
-    case TEMPO_SOURCE_SYNC:
-      update_sync();
-      break;
-    case TEMPO_SOURCE_MIDI:
-      break;
+    inline void setHandleTempoEvent(void (*fptr)()) {
+      tTempoCallback = fptr;
+    }
+    inline void setHandleAlignEvent(void (*fptr)()) {
+      tAlignCallback = fptr;
+    }
+    void update(const uint32_t synth_speed) {
+      if(_source != TEMPO_SOURCE_SYNC && Sync::detect()){
+        _source = TEMPO_SOURCE_SYNC;
+      }
+
+      switch(_source) {
+        case TEMPO_SOURCE_INTERNAL:
+          tempo.update_internal(*this, synth_speed);
+          break;
+        case TEMPO_SOURCE_SYNC:
+          update_sync();
+          break;
+        case TEMPO_SOURCE_MIDI:
+          break;
+      }
+
+      if(syncStart >= TEMPO_SYNC_DIVIDER) {
+        Sync::write(LOW);
+      }
     }
 
-    if (syncStart >= TEMPO_SYNC_DIVIDER) {
-      Sync::write(LOW);
-    }
-  }
+    void midi_clock_received() {
+      if (_source != TEMPO_SOURCE_MIDI) {
+        _source = TEMPO_SOURCE_MIDI;
+      }
 
-  void midi_clock_received() {
-    if (_source != TEMPO_SOURCE_MIDI) {
-      _source = TEMPO_SOURCE_MIDI;
-    }
-
-    _previous_clock_time = micros();
-    trigger();
-  }
-
-  void reset_clock_source() {
-    _source = TEMPO_SOURCE_INTERNAL;
-    tempo.reset();
-    _previous_clock_time = micros();
-    _clock = 0;
-    trigger();
-  }
-
-  bool is_clock_source_internal() const {
-    return _source == TEMPO_SOURCE_INTERNAL;
-  }
-
-private:
-  enum Source {
-    TEMPO_SOURCE_MIDI,
-    TEMPO_SOURCE_SYNC,
-    TEMPO_SOURCE_INTERNAL
-  };
-
-  Tempo tempo;
-  elapsedMillis syncStart;
-  void (*tTempoCallback)();
-  void (*tAlignCallback)();
-  Source _source = TEMPO_SOURCE_INTERNAL;
-  uint32_t _previous_clock_time = 0;
-  uint32_t _previous_sync_time = 0;
-  uint32_t _tempo_interval = 0;
-  uint16_t _clock = 0;
-
-  void update_sync() {
-    if (!Sync::detect()) {
-      reset_clock_source();
-      return;
-    }
-
-    static uint8_t _sync_pin_previous_value = 1;
-    const uint8_t _sync_pin_value = Sync::read();
-
-    if (_sync_pin_previous_value && !_sync_pin_value) {
-      _tempo_interval = (micros() - _previous_sync_time) / TEMPO_SYNC_DIVIDER;
-      _clock = 0;
-      _previous_sync_time = micros();
       _previous_clock_time = micros();
-      if (tAlignCallback != 0) {
-        tAlignCallback();
+      trigger();
+    }
+    void reset_clock_source() {
+      _source = TEMPO_SOURCE_INTERNAL;
+      tempo.reset();
+      _previous_clock_time = micros();
+      _clock = 0;
+      trigger();
+    }
+    bool is_clock_source_internal() const {
+      return _source == TEMPO_SOURCE_INTERNAL;
+    }
+  private:
+
+    enum Source{
+      TEMPO_SOURCE_MIDI,
+      TEMPO_SOURCE_SYNC,
+      TEMPO_SOURCE_INTERNAL
+    };
+
+
+    Tempo tempo;
+    elapsedMillis syncStart;
+    void (*tTempoCallback)();
+    void (*tAlignCallback)();
+    Source _source = TEMPO_SOURCE_INTERNAL;
+    uint32_t _previous_clock_time = 0;
+    uint32_t _previous_sync_time = 0;
+    uint32_t _tempo_interval = 0;
+    uint16_t _clock = 0;
+
+    void update_sync() {
+      if (!Sync::detect()) {
+        reset_clock_source();
+        return;
       }
-      if (tTempoCallback != 0) {
-        trigger();
-      }
-    } else {
-      if (micros() - _previous_clock_time > _tempo_interval) {
-        if (_clock < TEMPO_SYNC_DIVIDER) {
-          if (tTempoCallback != 0) {
-            _previous_clock_time = micros();
-            trigger();
+
+      static uint8_t _sync_pin_previous_value = 1;
+      const uint8_t _sync_pin_value = Sync::read();
+
+      if(_sync_pin_previous_value && !_sync_pin_value) {
+        _tempo_interval = (micros() - _previous_sync_time) / TEMPO_SYNC_DIVIDER;
+        _clock = 0;
+        _previous_sync_time = micros();
+        _previous_clock_time = micros();
+        if (tAlignCallback != 0) {
+          tAlignCallback();
+        }
+        if (tTempoCallback != 0) {
+          trigger();
+        }
+      } else {
+        if(micros() - _previous_clock_time > _tempo_interval) {
+          if(_clock < TEMPO_SYNC_DIVIDER) {
+            if (tTempoCallback != 0) {
+              _previous_clock_time = micros();
+              trigger();
+            }
           }
         }
       }
+      _sync_pin_previous_value = _sync_pin_value;
     }
-    _sync_pin_previous_value = _sync_pin_value;
-  }
 
-  /*
-   * Calls the callback, updates the clock and sends out MIDI/Sync pulses
-   */
-  void trigger() {
-    midi_send_realtime(midi::Clock);
+    /*
+     * Calls the callback, updates the clock and sends out MIDI/Sync pulses
+     */
+    void trigger() {
+      midi_send_realtime(midi::Clock);
 
-    if ((_clock % Sequencer::PULSES_PER_QUARTER_NOTE) == 0) {
-      _clock = 0;
+      if((_clock % Sequencer::PULSES_PER_QUARTER_NOTE) == 0) {
+        _clock = 0;
+      }
+      if((_clock % TEMPO_SYNC_DIVIDER) == 0) {
+        Sync::write(HIGH);
+        syncStart = 0;
+      } 
+      if (tTempoCallback != 0) {
+        tTempoCallback();
+      }
+      if (_source == TEMPO_SOURCE_MIDI) {
+        _previous_clock_time = micros();
+      }
+      _clock++;
     }
-    if ((_clock % TEMPO_SYNC_DIVIDER) == 0) {
-      Sync::write(HIGH);
-      syncStart = 0;
-    }
-    if (tTempoCallback != 0) {
-      tTempoCallback();
-    }
-    if (_source == TEMPO_SOURCE_MIDI) {
-      _previous_clock_time = micros();
-    }
-    _clock++;
-  }
 };
 
 #endif

--- a/firmware/TempoHandler.h
+++ b/firmware/TempoHandler.h
@@ -27,12 +27,12 @@
 #include "lib/tempo.h"
 #include "seq.h"
 #include <MIDI.h>
-#include <stdint.h>
+#include <cstdint>
 
 void midi_send_realtime(const midi::MidiType message);
 
 class TempoHandler {
-  friend class Tempo;
+  friend struct Tempo;
 
 public:
   TempoHandler() {
@@ -80,7 +80,9 @@ public:
   void reset_clock_source() {
     _source = TEMPO_SOURCE_INTERNAL;
     tempo.reset();
-    reset_clock();
+    _previous_clock_time = micros();
+    _clock = 0;
+    trigger();
   }
 
   bool is_clock_source_internal() const {
@@ -103,11 +105,6 @@ private:
   uint32_t _previous_sync_time = 0;
   uint32_t _tempo_interval = 0;
   uint16_t _clock = 0;
-
-  void reset_clock() {
-    _previous_clock_time = micros();
-    _clock = 0;
-  }
 
   void update_sync() {
     if (!Sync::detect()) {

--- a/firmware/TempoHandler.h
+++ b/firmware/TempoHandler.h
@@ -86,6 +86,10 @@ class TempoHandler
     bool is_clock_source_internal() const {
       return _source == TEMPO_SOURCE_INTERNAL;
     }
+
+    void set_MIDI_source(){
+      _source = TEMPO_SOURCE_MIDI;
+    }
   private:
 
     enum Source{

--- a/firmware/seq.cpp
+++ b/firmware/seq.cpp
@@ -51,32 +51,16 @@ Sequencer::Sequencer(Output::Callbacks callbacks,
   }
 }
 
-void Sequencer::start() {
-  running = true;
-  clock = 0;
-  const uint8_t step_index = current_step + step_offset;
-  const Step cur_step = steps[wrapped_step(step_index)];
-  if (cur_step.enabled) {
-    step_gate.trigger();
-    output.on(cur_step.note);
-    last_played_step = step_index;
-  }
+void Sequencer::set_running(const bool running) {
+  this->running = running;
 }
 
-void Sequencer::restart() {
-  current_step = 0;
-  last_played_step = NUM_STEPS;
+void Sequencer::reset() {
+  const uint8_t divider = divider_from_speed_mod(speed_mod);
+  clock = divider-1;
+  last_played_step = UINT8_MAX;
   step_played_live = false;
-  start();
-}
-
-void Sequencer::stop() {
-  if (running) {
-    clock = 0;
-    running = false;
-    inc_current_step(); // Start from the next step when playing again
-    output.off();
-  }
+  output.off();
 }
 
 void Sequencer::update_gate(const uint32_t delta_micros) {

--- a/firmware/seq.cpp
+++ b/firmware/seq.cpp
@@ -1,6 +1,10 @@
 #include "seq.h"
 
-enum Zone { Early, Middle, Late };
+enum Zone {
+  Early,
+  Middle,
+  Late
+};
 
 namespace Sequencer {
 
@@ -70,7 +74,7 @@ void Sequencer::stop() {
   if (running) {
     clock = 0;
     running = false;
-    inc_current_step(); // So that we start from the next step when playing again
+    inc_current_step(); // Start from the next step when playing again
     output.off();
   }
 }

--- a/firmware/seq.cpp
+++ b/firmware/seq.cpp
@@ -51,10 +51,6 @@ Sequencer::Sequencer(Output::Callbacks callbacks,
   }
 }
 
-void Sequencer::set_running(const bool running) {
-  this->running = running;
-}
-
 void Sequencer::reset_playback() {
   const uint8_t divider = divider_from_speed_mod(speed_mod);
   clock = divider - 1;

--- a/firmware/seq.cpp
+++ b/firmware/seq.cpp
@@ -51,13 +51,14 @@ Sequencer::Sequencer(Output::Callbacks callbacks,
   }
 }
 
-void Sequencer::reset_playback() {
+void Sequencer::run() {
   const uint8_t divider = divider_from_speed_mod(speed_mod);
   clock = divider - 1;
   last_played_step = UINT8_MAX;
   step_played_live = false;
   output.off();
-}
+  running = true;
+};
 
 void Sequencer::update_gate(const uint32_t delta_micros) {
   step_gate.update(delta_micros);
@@ -168,6 +169,7 @@ void Sequencer::hold_note(const uint8_t note, const uint8_t velocity) {
   arp.hold_note(note, velocity);
 
   const uint8_t active_note_count = arp.count();
+  
   if (active_note_count > 0) {
     const uint8_t arp_note = arp.recent_note();
     const Zone zone = get_zone(clock, speed_mod);

--- a/firmware/seq.cpp
+++ b/firmware/seq.cpp
@@ -55,9 +55,9 @@ void Sequencer::set_running(const bool running) {
   this->running = running;
 }
 
-void Sequencer::reset() {
+void Sequencer::reset_playback() {
   const uint8_t divider = divider_from_speed_mod(speed_mod);
-  clock = divider-1;
+  clock = divider - 1;
   last_played_step = UINT8_MAX;
   step_played_live = false;
   output.off();

--- a/firmware/seq.h
+++ b/firmware/seq.h
@@ -121,7 +121,16 @@ typedef void (&OnRunnningAdvance)(Sequencer &);
 
 struct Sequencer {
   Sequencer(Output::Callbacks callbacks, OnRunnningAdvance on_running_advance);
-  void set_running(bool running);
+
+  // `run()` and `stop()` controls the running state of the Sequencer, however
+  // is no internal ticker. In order to advance, `tick_clock()` must be called.
+  void run() {
+    running = true;
+  };
+  void stop() {
+    running = false;
+  }
+
   void reset_playback();
   void advance();
   void tick_clock();

--- a/firmware/seq.h
+++ b/firmware/seq.h
@@ -121,9 +121,8 @@ typedef void (&OnRunnningAdvance)(Sequencer &);
 
 struct Sequencer {
   Sequencer(Output::Callbacks callbacks, OnRunnningAdvance on_running_advance);
-  void start();
-  void restart();
-  void stop();
+  void set_running(bool running);
+  void reset();
   void advance();
   void tick_clock();
   void update_gate(uint32_t delta_micros);

--- a/firmware/seq.h
+++ b/firmware/seq.h
@@ -124,14 +124,11 @@ struct Sequencer {
 
   // `run()` and `stop()` controls the running state of the Sequencer, however
   // is no internal ticker. In order to advance, `tick_clock()` must be called.
-  void run() {
-    running = true;
-  };
+  void run();
   void stop() {
     running = false;
   }
 
-  void reset_playback();
   void advance();
   void tick_clock();
   void update_gate(uint32_t delta_micros);

--- a/firmware/seq.h
+++ b/firmware/seq.h
@@ -122,7 +122,7 @@ typedef void (&OnRunnningAdvance)(Sequencer &);
 struct Sequencer {
   Sequencer(Output::Callbacks callbacks, OnRunnningAdvance on_running_advance);
   void set_running(bool running);
-  void reset();
+  void reset_playback();
   void advance();
   void tick_clock();
   void update_gate(uint32_t delta_micros);

--- a/platform/brains2/src/duo/main.cpp
+++ b/platform/brains2/src/duo/main.cpp
@@ -373,10 +373,12 @@ static void main_init(AudioAmplifier& headphone_preamp, AudioAmplifier& speaker_
   audio_init();
   AudioInterrupts();
 
-  MIDI.setHandleStart(sequencer_restart);
-  usbMIDI.setHandleStart(sequencer_restart);
-  MIDI.setHandleContinue(sequencer_restart);
-  usbMIDI.setHandleContinue(sequencer_restart);
+  MIDI.setHandleStart(sequencer_start_from_MIDI);
+  usbMIDI.setHandleStart(sequencer_start_from_MIDI);
+
+  MIDI.setHandleContinue(sequencer_start_from_MIDI);
+  usbMIDI.setHandleContinue(sequencer_start_from_MIDI);
+
   MIDI.setHandleStop(sequencer_stop);
   usbMIDI.setHandleStop(sequencer_stop);
 

--- a/test/firmware/sequencer_test.cpp
+++ b/test/firmware/sequencer_test.cpp
@@ -74,7 +74,7 @@ void stops_playing_note_after_gate_duration() {
   auto seq = make_cleared_sequencer();
   const auto gate_len = 10;
   seq.set_gate_length(gate_len);
-  seq.set_running(true);
+  seq.run();
   const auto note = 123;
   seq.set_step_note(1, note);
   seq.toggle_step(1);
@@ -99,7 +99,7 @@ void records_early_live_note() {
   auto seq = make_cleared_sequencer();
   const uint8_t gate_len = 5;
   seq.set_gate_length(gate_len);
-  seq.set_running(true);
+  seq.run();
 
   seq.tick_clock();
   ASSERT_EQ(0, seq.cur_step_index());
@@ -122,7 +122,7 @@ void records_late_live_note() {
   auto seq = make_cleared_sequencer();
   const uint8_t gate_len = 5;
   seq.set_gate_length(gate_len);
-  seq.set_running(true);
+  seq.run();
 
   // Tick to end of current step
   for (unsigned i = 0; i < Sequencer::TICKS_PER_STEP - 1; ++i) {
@@ -156,7 +156,7 @@ void does_not_record_middle_live_notes() {
   auto seq = make_cleared_sequencer();
   const uint8_t gate_len = 5;
   seq.set_gate_length(gate_len);
-  seq.set_running(true);
+  seq.run();
 
   // Tick to next step to make sure clock is note 0.
   tick_to_next_step(seq);
@@ -211,7 +211,7 @@ void retriggers_held_notes_on_advance() {
   auto seq = make_cleared_sequencer();
   const auto gate_len = 1;
   seq.set_gate_length(gate_len);
-  seq.set_running(true);
+  seq.run();
 
   seq.hold_note(1);
   seq.update_gate(1);
@@ -240,7 +240,7 @@ void respects_step_offset_during_playback() {
   set_all_steps_active(seq, true);
   ASSERT_EQ(Sequencer::NUM_STEPS, count_enabled_steps(seq));
 
-  seq.set_running(true);
+  seq.run();
   ASSERT_PLAYED_COUNT(0);
 
   seq.advance();
@@ -260,7 +260,7 @@ void respects_step_offset_during_playback() {
 void arp_does_not_replay_note_when_lower_added() {
   auto seq = make_cleared_sequencer();
   seq.set_gate_length(10);
-  seq.set_running(true);
+  seq.run();
   seq.hold_note(1);
   seq.hold_note(3);
   ASSERT_PLAYED_COUNT(1);
@@ -282,7 +282,7 @@ void plays_randomized_step() {
     seq.set_step_note(step, step);
   }
 
-  seq.set_running(true);
+  seq.run();
   seq.advance();
   ASSERT_PLAYED_COUNT(1);
   ASSERT_EQ(1, NoteTracker::last_note);

--- a/test/firmware/sequencer_test.cpp
+++ b/test/firmware/sequencer_test.cpp
@@ -74,7 +74,7 @@ void stops_playing_note_after_gate_duration() {
   auto seq = make_cleared_sequencer();
   const auto gate_len = 10;
   seq.set_gate_length(gate_len);
-  seq.start();
+  seq.set_running(true);
   const auto note = 123;
   seq.set_step_note(1, note);
   seq.toggle_step(1);
@@ -99,7 +99,7 @@ void records_early_live_note() {
   auto seq = make_cleared_sequencer();
   const uint8_t gate_len = 5;
   seq.set_gate_length(gate_len);
-  seq.start();
+  seq.set_running(true);
 
   seq.tick_clock();
   ASSERT_EQ(0, seq.cur_step_index());
@@ -122,7 +122,7 @@ void records_late_live_note() {
   auto seq = make_cleared_sequencer();
   const uint8_t gate_len = 5;
   seq.set_gate_length(gate_len);
-  seq.start();
+  seq.set_running(true);
 
   // Tick to end of current step
   for (unsigned i = 0; i < Sequencer::TICKS_PER_STEP - 1; ++i) {
@@ -156,7 +156,7 @@ void does_not_record_middle_live_notes() {
   auto seq = make_cleared_sequencer();
   const uint8_t gate_len = 5;
   seq.set_gate_length(gate_len);
-  seq.start();
+  seq.set_running(true);
 
   // Tick to next step to make sure clock is note 0.
   tick_to_next_step(seq);
@@ -211,7 +211,7 @@ void retriggers_held_notes_on_advance() {
   auto seq = make_cleared_sequencer();
   const auto gate_len = 1;
   seq.set_gate_length(gate_len);
-  seq.start();
+  seq.set_running(true);
 
   seq.hold_note(1);
   seq.update_gate(1);
@@ -240,19 +240,19 @@ void respects_step_offset_during_playback() {
   set_all_steps_active(seq, true);
   ASSERT_EQ(Sequencer::NUM_STEPS, count_enabled_steps(seq));
 
-  seq.start();
-  ASSERT_PLAYED_COUNT(1);
+  seq.set_running(true);
+  ASSERT_PLAYED_COUNT(0);
 
   seq.advance();
   seq.update_gate(1);
 
-  ASSERT_PLAYED_COUNT(2);
+  ASSERT_PLAYED_COUNT(1);
   ASSERT_EQ(1, NoteTracker::last_note);
   seq.set_step_offset(2);
 
   seq.advance();
   seq.update_gate(1);
-  ASSERT_PLAYED_COUNT(3);
+  ASSERT_PLAYED_COUNT(2);
   ASSERT_EQ(4, NoteTracker::last_note);
   ASSERT_EQ(4, seq.cur_step_index());
 }
@@ -260,7 +260,7 @@ void respects_step_offset_during_playback() {
 void arp_does_not_replay_note_when_lower_added() {
   auto seq = make_cleared_sequencer();
   seq.set_gate_length(10);
-  seq.start();
+  seq.set_running(true);
   seq.hold_note(1);
   seq.hold_note(3);
   ASSERT_PLAYED_COUNT(1);
@@ -282,14 +282,15 @@ void plays_randomized_step() {
     seq.set_step_note(step, step);
   }
 
-  seq.start();
+  seq.set_running(true);
+  seq.advance();
   ASSERT_PLAYED_COUNT(1);
-  ASSERT_EQ(0, NoteTracker::last_note);
+  ASSERT_EQ(1, NoteTracker::last_note);
   seq.set_step_offset(offset);
   ASSERT_PLAYED_COUNT(1);
   seq.advance();
   ASSERT_PLAYED_COUNT(2);
-  ASSERT_EQ(1 + offset, NoteTracker::last_note);
+  ASSERT_EQ(2 + offset, NoteTracker::last_note);
 }
 
 } // namespace Tests

--- a/test/firmware/sequencer_test.cpp
+++ b/test/firmware/sequencer_test.cpp
@@ -1,6 +1,6 @@
 #include "sequencer_helpers.h"
 
-// #define SINGLE_TEST records_early_live_note
+/* #define SINGLE_TEST retriggers_held_notes_on_advance */
 
 namespace NoteTracker {
 static bool note_active = false;
@@ -102,18 +102,18 @@ void records_early_live_note() {
   seq.run();
 
   seq.tick_clock();
-  ASSERT_EQ(0, seq.cur_step_index());
+  ASSERT_EQ(1, seq.cur_step_index());
   const auto note = 1;
   seq.hold_note(note);
   seq.update_gate(1);
   seq.release_note(note);
 
-  ASSERT_ONLY_ENABLED_STEP(seq, 0);
+  ASSERT_ONLY_ENABLED_STEP(seq, 1);
   ASSERT_NOTE_PLAYING(true);
 
   tick_to_next_step(seq);
   seq.update_gate(gate_len);
-  ASSERT_ONLY_ENABLED_STEP(seq, 0);
+  ASSERT_ONLY_ENABLED_STEP(seq, 1);
   ASSERT_NOTE_PLAYING(false);
   ASSERT_PLAYED_COUNT(1);
 }
@@ -128,20 +128,20 @@ void records_late_live_note() {
   for (unsigned i = 0; i < Sequencer::TICKS_PER_STEP - 1; ++i) {
     seq.tick_clock();
   }
-  ASSERT_EQ(0, seq.cur_step_index());
+  ASSERT_EQ(1, seq.cur_step_index());
 
   const auto note = 1;
   seq.hold_note(note);
 
-  ASSERT_ONLY_ENABLED_STEP(seq, 1);
+  ASSERT_ONLY_ENABLED_STEP(seq, 2);
   seq.update_gate(1);
 
   seq.release_all_notes();
-  ASSERT_ONLY_ENABLED_STEP(seq, 1);
+  ASSERT_ONLY_ENABLED_STEP(seq, 2);
 
   ASSERT_PLAYED_COUNT(0);
   tick_to_next_step(seq);
-  ASSERT_EQ(1, seq.cur_step_index());
+  ASSERT_EQ(2, seq.cur_step_index());
   ASSERT_NOTE_PLAYING(true);
   seq.update_gate(gate_len);
   ASSERT_NOTE_PLAYING(true);
@@ -212,6 +212,7 @@ void retriggers_held_notes_on_advance() {
   const auto gate_len = 1;
   seq.set_gate_length(gate_len);
   seq.run();
+  seq.tick_clock();
 
   seq.hold_note(1);
   seq.update_gate(1);
@@ -261,6 +262,7 @@ void arp_does_not_replay_note_when_lower_added() {
   auto seq = make_cleared_sequencer();
   seq.set_gate_length(10);
   seq.run();
+  seq.tick_clock();
   seq.hold_note(1);
   seq.hold_note(3);
   ASSERT_PLAYED_COUNT(1);


### PR DESCRIPTION
This should make the Duo behave like the Volca in terms of sync, meaning we trigger a new sync pulse immediately when the Duo sequencer starts.
The main changes are in https://github.com/datomusic/duo-imxrt/pull/155/commits/f95c8ad2e50df823d232ef525ebb0a788a0fd739 where I simplified the sequencer behaviour and made playback of notes driven completely by the tempo. When starting the sequencer, we simply set the playback clock so that the next tick will trigger the next step. and reset `tempo_handler`.

From my testing with a volca drum, this keeps things synced well.