### PR TITLE
Throttle sending of MIDI CC

### DIFF
--- a/platform/brains2/src/duo/main.cpp
+++ b/platform/brains2/src/duo/main.cpp
@@ -319,13 +319,13 @@ static void main_loop(){
       if (millis() - frame_time > frame_interval) {
         frame_time = millis();
         led_update();
+        midi_send_cc();
         FastLED.show();
       } else {
         DatoUSB::background_update();
         midi_handle();
         pitch_update(); // ~30us
         synth_update(); // ~ 100us
-        midi_send_cc();
         Drums::update(); // ~ 700us
         sequencer_update();
         headphone_jack_check();


### PR DESCRIPTION
While working on the sync issues, I noticed we're spamming CC's when moving sliders, which in turn prevents midi clocks from going out correctly.
This small fix throttles it enough to prevent overload on the sender, but perhaps we want to introduce a new time window specifically for outgoing MIDI.