### PR TITLE
Fix phase of MIDI sync

### DIFF
--- a/firmware/Sequencer.h
+++ b/firmware/Sequencer.h
@@ -5,6 +5,8 @@
  Note timing is divided into 24 steps per quarter note
  */
 
+#include <cstdint>
+
 uint32_t last_sequencer_update;
 bool double_speed = false;
 
@@ -56,6 +58,13 @@ void sequencer_start() {
   sequencer.run();
 }
 
+void sequencer_start_from_MIDI() {
+  MIDI.sendRealTime(midi::Start);
+  usbMIDI.sendRealTime(midi::Start);
+  tempo_handler.set_MIDI_source();
+  sequencer.run();
+}
+
 void sequencer_toggle_start() {
   if (sequencer.is_running()) {
     sequencer_stop();
@@ -83,13 +92,6 @@ static void sequencer_init() {
 
   sequencer_stop();
   double_speed = false;
-}
-
-void sequencer_restart() {
-  MIDI.sendRealTime(midi::Start);
-  usbMIDI.sendRealTime(midi::Start);
-  delay(1);
-  sequencer.run();
 }
 
 #define keyboard_set_note(note) sequencer.hold_note(note)

--- a/firmware/TempoHandler.h
+++ b/firmware/TempoHandler.h
@@ -86,6 +86,10 @@ class TempoHandler
     bool is_clock_source_internal() const {
       return _source == TEMPO_SOURCE_INTERNAL;
     }
+
+    void set_MIDI_source(){
+      _source = TEMPO_SOURCE_MIDI;
+    }
   private:
 
     enum Source{

--- a/platform/brains2/src/duo/main.cpp
+++ b/platform/brains2/src/duo/main.cpp
@@ -373,10 +373,12 @@ static void main_init(AudioAmplifier& headphone_preamp, AudioAmplifier& speaker_
   audio_init();
   AudioInterrupts();
 
-  MIDI.setHandleStart(sequencer_restart);
-  usbMIDI.setHandleStart(sequencer_restart);
-  MIDI.setHandleContinue(sequencer_restart);
-  usbMIDI.setHandleContinue(sequencer_restart);
+  MIDI.setHandleStart(sequencer_start_from_MIDI);
+  usbMIDI.setHandleStart(sequencer_start_from_MIDI);
+
+  MIDI.setHandleContinue(sequencer_start_from_MIDI);
+  usbMIDI.setHandleContinue(sequencer_start_from_MIDI);
+
   MIDI.setHandleStop(sequencer_stop);
   usbMIDI.setHandleStop(sequencer_stop);
 


### PR DESCRIPTION
fixes https://github.com/datomusic/duo-imxrt/issues/158

With these changes  (on top of the `fix-sync-reset` branch), the Duo starts playback in phase when triggered from another Duo with the latest firmware, and it should also work correctly with any other midi sender, although I have not tested that properly yet.

The older Duo (`brains1`, and older sequencer for `brains2`) firmware does not align outgoing MIDI pulses with the sequencer steps, but since we can now reset the playback instantly with the play button, the phase can be manually aligned.