### PR TITLE
Add stubs for unused but missing functions in libc-nano

### DIFF
--- a/platform/brains2/src/duo/main.cpp
+++ b/platform/brains2/src/duo/main.cpp
@@ -1,5 +1,6 @@
 #include "Arduino.h"
 
+#include "syscall_stubs.h"
 #include "lib/board_init.h"
 #include "lib/leds.h"
 #include "lib/audio.h"

--- a/platform/brains2/src/duo/syscall_stubs.h
+++ b/platform/brains2/src/duo/syscall_stubs.h
@@ -1,0 +1,34 @@
+extern "C" {
+
+int _getpid(void) {
+  return -1;
+}
+
+int _kill(int pid, int sig) {
+  return -1;
+}
+
+int _read(int file, char *ptr, int len) {
+  return -1;
+}
+
+int _write(int file, char *ptr, int len) {
+  return -1;
+}
+
+int _close(int file) {
+  return -1;
+}
+
+int _fstat(int file, struct stat *st) {
+  return 0;
+}
+
+int _isatty(int file) {
+  return 0;
+}
+
+int _lseek(int file, int ptr, int dir) {
+  return 0;
+}
+}


### PR DESCRIPTION
This gets rid of linker warnings related to `libc-nano`.
We are never calling these (if we were, we would have firmware crashes), and the warnings are noisy and distracts from real warnings we might care about.

I am not sure if these functions are referenced or why else we're getting the linker warnings but from some searches we're not alone in seeing them.
My conclusion is that the situation has always existed, but libc-nano has added warnings to make it explicit at some point.

I currently don't think there's any risk in us adding these stubs.