### PR TITLE
[WIP] Brains 2.3 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ armgcc/release/
 compile_commands.json
 *.o
 *.d
+.aider*

--- a/brains2/apps/duo/boards/DUO_BRAINS_2.3/drums.h
+++ b/brains2/apps/duo/boards/DUO_BRAINS_2.3/drums.h
@@ -1,0 +1,70 @@
+#ifndef DRUMS_H_D3BUGV50
+#define DRUMS_H_D3BUGV50
+
+#include "../../pins.h"
+
+namespace Drums {
+
+bool hat_l = 0;
+bool hat_m = 0;
+bool hat_r = 0;
+bool kick_l = 0;
+bool kick_m = 0;
+bool kick_r = 0;
+  
+void init() {
+  drum_init();
+}
+
+void update() {
+  static unsigned long update_time;
+
+  if(millis() - update_time > 10) {
+    update_time = millis();
+    hat_l = pinRead(HAT_PAD_L_PIN);
+    hat_m = pinRead(HAT_PAD_M_PIN);
+    hat_r = pinRead(HAT_PAD_R_PIN);
+    kick_l = pinRead(KICK_PAD_L_PIN);
+    kick_m = pinRead(KICK_PAD_M_PIN);
+    kick_r = pinRead(KICK_PAD_R_PIN);
+
+    if (hat_playing) {
+      if (!hat_l && !hat_r && !hat_m) {
+        hat_noteoff();
+      }
+    } else {
+      if (hat_l && hat_m) {
+        hat_noteon(31);
+      } else if (hat_l) {
+        hat_noteon(0);
+      } else if (hat_r && hat_m) {
+        hat_noteon(95);
+      } else if (hat_r) {
+        hat_noteon(127);
+      } else if (hat_m) {
+        hat_noteon(64);
+      }
+    } 
+
+    if (kick_playing) {
+      if (!kick_l && !kick_r && !kick_m) {
+        kick_noteoff();
+      }
+    } else {
+      if (kick_l && kick_m) {
+        kick_noteon(31);
+      } else if (kick_l) {
+        kick_noteon(0);
+      } else if (kick_r && kick_m) {
+        kick_noteon(95);
+      } else if (kick_r) {
+        kick_noteon(127);
+      } else if (kick_m) {
+        kick_noteon(63);
+      }
+    }
+  }
+ }
+} // namespace Drums
+
+#endif /* end of include guard: DRUMS_H_D3BUGV50 */

--- a/brains2/apps/duo/main.cpp
+++ b/brains2/apps/duo/main.cpp
@@ -288,20 +288,20 @@ static void headphone_jack_check() {
   if (millis() > next_jack_check_time) {
     next_jack_check_time = millis() + jack_check_interval; 
     if(headphone_jack_detected()) {
-    MAIN_GAIN = HEADPHONE_MAIN_GAIN;
-    DELAY_GAIN = HEADPHONE_DELAY_GAIN;
-    KICK_GAIN = HEADPHONE_KICK_GAIN;
-    HAT_GAIN = HEADPHONE_HAT_GAIN;
-    Audio::headphone_enable();
-    Audio::amp_disable();
-  } else {
-    MAIN_GAIN = SPEAKER_MAIN_GAIN;
-    DELAY_GAIN = SPEAKER_DELAY_GAIN;
-    KICK_GAIN = SPEAKER_KICK_GAIN;
-    HAT_GAIN = SPEAKER_HAT_GAIN;
-    Audio::headphone_disable();
-    Audio::amp_enable();
-  }
+      MAIN_GAIN = HEADPHONE_MAIN_GAIN;
+      DELAY_GAIN = HEADPHONE_DELAY_GAIN;
+      KICK_GAIN = HEADPHONE_KICK_GAIN;
+      HAT_GAIN = HEADPHONE_HAT_GAIN;
+      Audio::headphone_enable();
+      Audio::amp_disable();
+    } else {
+      MAIN_GAIN = SPEAKER_MAIN_GAIN;
+      DELAY_GAIN = SPEAKER_DELAY_GAIN;
+      KICK_GAIN = SPEAKER_KICK_GAIN;
+      HAT_GAIN = SPEAKER_HAT_GAIN;
+      Audio::headphone_disable();
+      Audio::amp_enable();
+    }
   }
 }
 
@@ -367,7 +367,7 @@ static void main_init(AudioAmplifier& headphone_preamp, AudioAmplifier& speaker_
   speaker_preamp.gain(SPEAKER_GAIN);
   audio_init();
   AudioInterrupts();
-
+  Audio::amp_init();
   Audio::headphone_enable();
   Audio::amp_enable();
 

--- a/brains2/core/boards/DUO_BRAINS_2.1/audio.cpp
+++ b/brains2/core/boards/DUO_BRAINS_2.1/audio.cpp
@@ -23,6 +23,10 @@ void headphone_disable(void) {
   GPIO_PinWrite(HP_ENABLE_PORT, HP_ENABLE_PIN, 0);
 }
 
+void amp_init(void) {
+
+}
+
 void amp_enable(void) {
   IOMUXC_SetPinMux(AMP_MUTE_PINMUX, 0U);
   gpio_pin_config_t amp_mute_config = {kGPIO_DigitalOutput, 0};

--- a/brains2/core/boards/DUO_BRAINS_2.3/audio.cpp
+++ b/brains2/core/boards/DUO_BRAINS_2.3/audio.cpp
@@ -1,9 +1,5 @@
 #include "lib/variant.h"
 
-namespace Audio {
-  bool amp_enable_polarity = false;
-}
-
 #define HP_ENABLE_PINMUX IOMUXC_GPIO_AD_11_GPIOMUX_IO25
 #define HP_ENABLE_PORT GPIO1
 #define HP_ENABLE_PIN 25U
@@ -13,6 +9,8 @@ namespace Audio {
 #define AMP_MUTE_PIN 24U
 
 namespace Audio {
+bool amp_enable_polarity = false;
+
 void headphone_enable(void) {
   IOMUXC_SetPinMux(HP_ENABLE_PINMUX, 0U);
   gpio_pin_config_t hp_enable_config = {kGPIO_DigitalOutput, 0};
@@ -28,32 +26,32 @@ void headphone_disable(void) {
 }
 
 void amp_enable(void) {
-  IOMUXC_SetPinMux(AMP_MUTE_PINMUX, 0U);
-  gpio_pin_config_t amp_mute_config = {kGPIO_DigitalOutput, 0};
-  GPIO_PinInit(AMP_MUTE_PORT, AMP_MUTE_PIN, &amp_mute_config);
-  GPIO_PinWrite(AMP_MUTE_PORT, AMP_MUTE_PIN, 1);
+  GPIO_PinWrite(AMP_MUTE_PORT, AMP_MUTE_PIN, (amp_enable_polarity ? 1 : 0));
 }
 
 void amp_disable(void) {
-  IOMUXC_SetPinMux(AMP_MUTE_PINMUX, 0U);
-  gpio_pin_config_t amp_mute_config = {kGPIO_DigitalOutput, 0};
-  GPIO_PinInit(AMP_MUTE_PORT, AMP_MUTE_PIN, &amp_mute_config);
-  GPIO_PinWrite(AMP_MUTE_PORT, AMP_MUTE_PIN, 0);
+  GPIO_PinWrite(AMP_MUTE_PORT, AMP_MUTE_PIN, (amp_enable_polarity ? 0 : 1));
 }
 
 void amp_init(void) {
-  // Configure as input to read current state
+  // BIT 12 should be 0 to disable pull/keeper
+  const uint32_t IOMUXC_PINCONFIG_DEFAULT = 0xB0U;
+
   IOMUXC_SetPinMux(AMP_MUTE_PINMUX, 0U);
+  IOMUXC_SetPinConfig(AMP_MUTE_PINMUX, IOMUXC_PINCONFIG_DEFAULT);
   gpio_pin_config_t amp_mute_config = {kGPIO_DigitalInput, 0};
   GPIO_PinInit(AMP_MUTE_PORT, AMP_MUTE_PIN, &amp_mute_config);
   
-  // Read current pin state to determine polarity
-  amp_enable_polarity = GPIO_PinRead(AMP_MUTE_PORT, AMP_MUTE_PIN);
+  // An external resistor sets the amp to mute at startup. 
+  // Some chips are active high others are active low
+  // Read its direction to determine the polarity
+  amp_enable_polarity = !(GPIO_PinRead(AMP_MUTE_PORT, AMP_MUTE_PIN));
   
+  IOMUXC_SetPinConfig(AMP_MUTE_PINMUX, (1<<12) | IOMUXC_PINCONFIG_DEFAULT);
   // Reconfigure as output with initial state
   amp_mute_config.direction = kGPIO_DigitalOutput;
   GPIO_PinInit(AMP_MUTE_PORT, AMP_MUTE_PIN, &amp_mute_config);
-  GPIO_PinWrite(AMP_MUTE_PORT, AMP_MUTE_PIN, amp_enable_polarity ? 1 : 0);
+  GPIO_PinWrite(AMP_MUTE_PORT, AMP_MUTE_PIN, (amp_enable_polarity ? 0 : 1));
 }
 
 } // namespace Audio

--- a/brains2/core/boards/DUO_BRAINS_2.3/audio.cpp
+++ b/brains2/core/boards/DUO_BRAINS_2.3/audio.cpp
@@ -1,0 +1,40 @@
+#include "lib/variant.h"
+
+#define HP_ENABLE_PINMUX IOMUXC_GPIO_AD_11_GPIOMUX_IO25
+#define HP_ENABLE_PORT GPIO1
+#define HP_ENABLE_PIN 25U
+
+#define AMP_MUTE_PINMUX IOMUXC_GPIO_AD_10_GPIOMUX_IO24
+#define AMP_MUTE_PORT GPIO1
+#define AMP_MUTE_PIN 24U
+
+namespace Audio {
+void headphone_enable(void) {
+  IOMUXC_SetPinMux(HP_ENABLE_PINMUX, 0U);
+  gpio_pin_config_t hp_enable_config = {kGPIO_DigitalOutput, 0};
+  GPIO_PinInit(HP_ENABLE_PORT, HP_ENABLE_PIN, &hp_enable_config);
+  GPIO_PinWrite(HP_ENABLE_PORT, HP_ENABLE_PIN, 1);
+}
+
+void headphone_disable(void) {
+  IOMUXC_SetPinMux(HP_ENABLE_PINMUX, 0U);
+  gpio_pin_config_t hp_enable_config = {kGPIO_DigitalOutput, 0};
+  GPIO_PinInit(HP_ENABLE_PORT, HP_ENABLE_PIN, &hp_enable_config);
+  GPIO_PinWrite(HP_ENABLE_PORT, HP_ENABLE_PIN, 0);
+}
+
+void amp_enable(void) {
+  IOMUXC_SetPinMux(AMP_MUTE_PINMUX, 0U);
+  gpio_pin_config_t amp_mute_config = {kGPIO_DigitalOutput, 0};
+  GPIO_PinInit(AMP_MUTE_PORT, AMP_MUTE_PIN, &amp_mute_config);
+  GPIO_PinWrite(AMP_MUTE_PORT, AMP_MUTE_PIN, 1);
+}
+
+void amp_disable(void) {
+  IOMUXC_SetPinMux(AMP_MUTE_PINMUX, 0U);
+  gpio_pin_config_t amp_mute_config = {kGPIO_DigitalOutput, 0};
+  GPIO_PinInit(AMP_MUTE_PORT, AMP_MUTE_PIN, &amp_mute_config);
+  GPIO_PinWrite(AMP_MUTE_PORT, AMP_MUTE_PIN, 0);
+}
+
+} // namespace Audio

--- a/brains2/core/boards/DUO_BRAINS_2.3/audio.cpp
+++ b/brains2/core/boards/DUO_BRAINS_2.3/audio.cpp
@@ -1,5 +1,9 @@
 #include "lib/variant.h"
 
+namespace Audio {
+  bool amp_enable_polarity = false;
+}
+
 #define HP_ENABLE_PINMUX IOMUXC_GPIO_AD_11_GPIOMUX_IO25
 #define HP_ENABLE_PORT GPIO1
 #define HP_ENABLE_PIN 25U
@@ -35,6 +39,21 @@ void amp_disable(void) {
   gpio_pin_config_t amp_mute_config = {kGPIO_DigitalOutput, 0};
   GPIO_PinInit(AMP_MUTE_PORT, AMP_MUTE_PIN, &amp_mute_config);
   GPIO_PinWrite(AMP_MUTE_PORT, AMP_MUTE_PIN, 0);
+}
+
+void amp_init(void) {
+  // Configure as input to read current state
+  IOMUXC_SetPinMux(AMP_MUTE_PINMUX, 0U);
+  gpio_pin_config_t amp_mute_config = {kGPIO_DigitalInput, 0};
+  GPIO_PinInit(AMP_MUTE_PORT, AMP_MUTE_PIN, &amp_mute_config);
+  
+  // Read current pin state to determine polarity
+  amp_enable_polarity = GPIO_PinRead(AMP_MUTE_PORT, AMP_MUTE_PIN);
+  
+  // Reconfigure as output with initial state
+  amp_mute_config.direction = kGPIO_DigitalOutput;
+  GPIO_PinInit(AMP_MUTE_PORT, AMP_MUTE_PIN, &amp_mute_config);
+  GPIO_PinWrite(AMP_MUTE_PORT, AMP_MUTE_PIN, amp_enable_polarity ? 1 : 0);
 }
 
 } // namespace Audio

--- a/brains2/core/boards/DUO_BRAINS_2.3/board_audio_output.h
+++ b/brains2/core/boards/DUO_BRAINS_2.3/board_audio_output.h
@@ -1,0 +1,26 @@
+#ifndef AUDIO_OUTPUT_H_VS0HQTKT
+#define AUDIO_OUTPUT_H_VS0HQTKT
+
+#include <output_pt8211.h>
+
+typedef AudioOutputPT8211 BoardAudioOutput;
+
+const float HEADPHONE_GAIN = 2.0f;
+const float SPEAKER_GAIN   = 2.0f;
+
+const float HEADPHONE_KICK_GAIN = 0.5f;
+const float HEADPHONE_HAT_GAIN = 0.5f;
+const float HEADPHONE_DELAY_GAIN = 1.0f;
+const float HEADPHONE_MAIN_GAIN = 0.8f;
+
+const float SPEAKER_MAIN_GAIN = 0.8f;
+const float SPEAKER_DELAY_GAIN = 1.0f;
+const float SPEAKER_KICK_GAIN = 0.8f;
+const float SPEAKER_HAT_GAIN = 1.0f;
+
+float MAIN_GAIN      = 0.8f;
+float DELAY_GAIN     = 1.0f;
+float KICK_GAIN      = 1.0f;
+float HAT_GAIN       = 1.2f;
+
+#endif /* end of include guard: AUDIO_OUTPUT_H_VS0HQTKT */

--- a/brains2/core/boards/DUO_BRAINS_2.3/led_pins.h
+++ b/brains2/core/boards/DUO_BRAINS_2.3/led_pins.h
@@ -1,0 +1,26 @@
+#ifndef LED_PINS_H_ZSKLTGQH
+#define LED_PINS_H_ZSKLTGQH
+
+#define PIN_LED_1 GPIO_08
+#define PIN_LED_2 GPIO_05
+#define PIN_LED_3 GPIO_03
+
+#define write_env_led(value)                                                   \
+  analogWrite(PIN_LED_3, 254 - (uint16_t)(value * 254.0f));
+
+#define write_osc_led(value)                                                   \
+  analogWrite(PIN_LED_1, (uint16_t)(value / 4.03f) + 1);
+
+#define write_filter_led(value)                                                \
+  analogWrite(PIN_LED_2, 254 - (uint16_t)((value * value) / 4128));
+
+#define blank_env_led() \
+  analogWrite(PIN_LED_3, 255);
+
+#define blank_osc_led() \
+  analogWrite(PIN_LED_1, 255);
+
+#define blank_filter_led() \
+  analogWrite(PIN_LED_2, 255);
+
+#endif /* end of include guard: LED_PINS_H_ZSKLTGQH */

--- a/brains2/core/boards/DUO_BRAINS_2.3/pins.cpp
+++ b/brains2/core/boards/DUO_BRAINS_2.3/pins.cpp
@@ -1,0 +1,116 @@
+#include "lib/pins.h"
+#include <Arduino.h>
+#include "fsl_gpio.h"
+#include "fsl_iomuxc.h"
+
+#define PIN_AMP_MUTE	       GPIO_AD_11
+#define PIN_HP_ENABLE	       GPIO_AD_11
+
+#define PIN_SYN_MUX_IO       GPIO_AD_14
+#define PIN_SYN_MUX2_IO      GPIO_AD_03
+#define PIN_BRN_MUX_IO       GPIO_AD_02
+
+#define PIN_SYN_ADDR0        GPIO_SD_00
+#define PIN_SYN_ADDR1        GPIO_SD_01
+#define PIN_SYN_ADDR2        GPIO_SD_02
+
+#define BENCHMARK_PIN        GPIO_SD_13
+
+// Channel 0 of BRN_MUX is connected to a resistor that goes nowhere
+#define UNCONNECTED_ANALOG   1
+
+int muxAnalogRead(const uint8_t channel, const uint8_t mux_pin) {
+  pinMode(mux_pin, INPUT_DISABLE);
+  digitalWrite(PIN_SYN_ADDR0, bitRead(channel, 0));
+  digitalWrite(PIN_SYN_ADDR1, bitRead(channel, 1));
+  digitalWrite(PIN_SYN_ADDR2, bitRead(channel, 2));
+  
+  delayMicroseconds(50);
+  return (analogRead(mux_pin));
+}
+
+uint8_t muxDigitalRead(const uint8_t channel, const uint8_t mux_pin, PinMode mode) {
+  pinMode(mux_pin, mode);
+
+  digitalWrite(PIN_SYN_ADDR0, bitRead(channel, 0));
+  digitalWrite(PIN_SYN_ADDR1, bitRead(channel, 1));
+  digitalWrite(PIN_SYN_ADDR2, bitRead(channel, 2));
+  delayMicroseconds(40);
+  
+  return digitalRead(mux_pin);
+}
+
+uint32_t potRead(const Pot pot) {
+  switch (pot) {
+    case FILTER_RES_POT:
+      return muxAnalogRead(0, PIN_SYN_MUX_IO);
+    case TEMPO_POT:
+      return (1023 - muxAnalogRead(4, PIN_BRN_MUX_IO));
+    case GATE_POT:
+      return (1023 - muxAnalogRead(6, PIN_BRN_MUX_IO));
+    case AMP_POT:
+      return muxAnalogRead(3, PIN_SYN_MUX_IO);
+    case FILTER_FREQ_POT:
+      return muxAnalogRead(5, PIN_SYN_MUX_IO);
+    case OSC_PW_POT:
+      return muxAnalogRead(7, PIN_SYN_MUX_IO);
+    case OSC_DETUNE_POT:
+      return muxAnalogRead(6, PIN_SYN_MUX_IO);
+    case AMP_ENV_POT:
+      return muxAnalogRead(1, PIN_SYN_MUX_IO);
+    default:
+      return 500;
+  }
+}
+
+bool pinRead(const Pin pin) {
+  switch (pin) {
+    case ACCENT_PIN:
+      return !(muxDigitalRead(0, PIN_SYN_MUX2_IO, INPUT));
+    case GLIDE_PIN:
+      return muxDigitalRead(4, PIN_SYN_MUX_IO, INPUT_PULLUP) == 0;
+    case DELAY_PIN:
+      return muxDigitalRead(2, PIN_SYN_MUX_IO, INPUT_PULLUP) != 0;
+    case BITC_PIN:
+      return !(muxDigitalRead(1, PIN_SYN_MUX2_IO, INPUT));
+    case HP_DETECT_PIN:
+      return (muxDigitalRead(3, PIN_BRN_MUX_IO, INPUT));
+    case SYNC_DETECT_PIN:
+      // The pulldown on the SYNC_DETECT pin is too weak
+      // So let's do an analogRead and compare it to 70%
+      // of fullscale
+      return !(muxAnalogRead(2, PIN_BRN_MUX_IO) < 700); 
+    case HAT_PAD_L_PIN:
+      return !(muxDigitalRead(3, PIN_SYN_MUX2_IO, INPUT));
+    case HAT_PAD_M_PIN:
+      return !(muxDigitalRead(2, PIN_SYN_MUX2_IO, INPUT));
+    case HAT_PAD_R_PIN:
+      return !(muxDigitalRead(4, PIN_SYN_MUX2_IO, INPUT));
+    case KICK_PAD_L_PIN:
+      return !(muxDigitalRead(5, PIN_SYN_MUX2_IO, INPUT));
+    case KICK_PAD_M_PIN:
+      return !(muxDigitalRead(7, PIN_SYN_MUX2_IO, INPUT));
+    case KICK_PAD_R_PIN:
+      return !(muxDigitalRead(6, PIN_SYN_MUX2_IO, INPUT));
+    default:
+      return false;
+  }
+}
+
+void pins_init() {
+  pinMode(PIN_HP_ENABLE, OUTPUT);
+  pinMode(PIN_AMP_MUTE, OUTPUT);
+
+  pinMode(PIN_SYN_ADDR0, OUTPUT);
+  pinMode(PIN_SYN_ADDR1, OUTPUT);
+  pinMode(PIN_SYN_ADDR2, OUTPUT);
+
+  // These pins are available as benchmarking pins
+  pinMode(GPIO_SD_13, OUTPUT);
+
+  randomSeed(potRead(GATE_POT) + potRead(FILTER_RES_POT) + potRead(AMP_ENV_POT));
+}
+
+bool headphone_jack_detected() {
+  return pinRead(HP_DETECT_PIN);
+}

--- a/brains2/core/lib/audio.h
+++ b/brains2/core/lib/audio.h
@@ -4,8 +4,10 @@
 namespace Audio {
   void headphone_enable(void);
   void headphone_disable(void);
+  void amp_init(void);
   void amp_enable(void);
   void amp_disable(void);
+  extern bool amp_enable_polarity;
 } // namespace Audio
 
 #endif /* end of include guard: AUDIO_H_OVLTWHKY */

--- a/brains2/core/lib/audio.h
+++ b/brains2/core/lib/audio.h
@@ -2,10 +2,10 @@
 #define AUDIO_H_OVLTWHKY
 
 namespace Audio {
-void headphone_enable(void);
-void headphone_disable(void);
-void amp_enable(void);
-void amp_disable(void);
+  void headphone_enable(void);
+  void headphone_disable(void);
+  void amp_enable(void);
+  void amp_disable(void);
 } // namespace Audio
 
 #endif /* end of include guard: AUDIO_H_OVLTWHKY */


### PR DESCRIPTION
DUO Brains 2.2 and 2.3 add support for an alternative audio amp. The amp has the same footprint but the ENABLE/MUTE pin has inverted polarity compared to the NCS2211 on the Brains 2.1 and earlier.

This branch adds functionality that senses the state of the ENABLE/MUTE pin at startup and defines the polarity accordingly. This works because there is a physical pull-up or pull-down resistor present on the board that mutes the amp at startup.

This pull request remains WIP until the final Brains 2.3 is released.