### PR TITLE
Revive the Brains 1 build

### DIFF
--- a/BRAINS1_BUILD.md
+++ b/BRAINS1_BUILD.md
@@ -1,0 +1,52 @@
+# Building the Brains 1 firmware
+
+_Revived 2026-08-10 on `brains1-revival`. Previous status: bit-rotted since the shared
+code restructure in 683f9b7 (Feb 2024); see git history of this file for the breakage list._
+
+## Building
+
+```sh
+cd brains1
+make -j8            # produces brains1.hex / brains1.elf
+make brains1.bin    # raw binary, used by `make dfu`
+```
+
+Toolchain: defaults to the newest Arm GNU Toolchain under
+`/Applications/ArmGNUToolchain/` on macOS (system path on Linux). Override with
+`make COMPILERPATH=/path/to/arm-none-eabi/bin/` (trailing slash required).
+Verified with 14.2.rel1.
+
+The MIDI library submodule must be checked out:
+`git submodule update --init brains2/libraries/MIDI`
+
+Flashing (unchanged): `make dfu` (dfu-util, 1fc9:8189), `make flash` (openocd),
+`make upload` (Teensy Loader).
+
+## What the revival changed
+
+- **`brains1/src/lib/midi_wrapper.{h,cpp}`** (new): Brains 1 implementation of the
+  `MIDI::` namespace API from `brains2/core/lib/midi_wrapper.h`, backed by the Arduino
+  MIDI library 4.x on `Serial1` (DIN MIDI, pins 0/1) plus the Teensy 3 core `usbMIDI`.
+  The old core has no usb sysex/start/stop handlers, so sysex is polled in
+  `MIDI::read()` (type 7, length in `getData1()`) and transport messages are dispatched
+  from the realtime callback.
+- **`src/src.ino`**: ported from the pre-2024 shared API to the current one, following
+  `brains2/apps/duo/main.cpp` — `Sequencer::Sequencer` object with callbacks instead of
+  `step_enable[]`/`sequencer_advance()` globals, `MIDI::init(Callbacks{...})` instead of
+  `PlatformMidi`/`usbMIDI` wiring, `MIDI::read(MIDI_CHANNEL)` in the loop,
+  default-constructed `TempoHandler`. `synth.gateLength` now stores the raw pot value
+  (the shared `sequencer_update()` does the 10–200 ms mapping).
+- **`src/Leds.h`**: `led_update()` ported to the sequencer API (same rendering as
+  brains2's `duo-firmware/src/Leds.h`), keeping the Brains 1 `analogWrite` panel LEDs.
+- **`src/Power.h`**: `MIDI::sendControlChange`, `sequencer.release_all_notes()`.
+- **`src/Synth.h`**: fixed `filter_resonance` (was an undeclared identifier).
+- **`src/pins_duo_1.0.h`**: fixed invalid include guard (`PINS_DUO_1.0_H`).
+- **`Makefile`**: `FIRMWARE_PATH` → `../shared/duo`; `COMPILERPATH` auto-detected and
+  overridable; Arduino MIDI library included/compiled from
+  `../brains2/libraries/MIDI/src`; `-std=gnu++14`.
+
+## Caveats
+
+- Builds clean (55 KB text, fits MK20DX256); **not yet tested on hardware**.
+- ~186 warnings remain, nearly all from the vendored FastLED/Teensy core.
+- `brains1` is still absent from CI (`.github/workflows/firmware-test.yml`).

--- a/brains1/Makefile
+++ b/brains1/Makefile
@@ -1,4 +1,7 @@
-FIRMWARE_PATH = $(abspath $(CURDIR)/../../firmware)
+FIRMWARE_PATH = $(abspath $(CURDIR)/../shared/duo)
+
+# Arduino MIDI library (shared with the Brains 2 build)
+MIDI_LIB_PATH = $(abspath $(CURDIR)/../brains2/libraries/MIDI/src)
 
 # The name of your project (used to name the compiled .hex file)
 TARGET = $(notdir $(CURDIR))
@@ -34,12 +37,13 @@ else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S),Darwin)
         # path location for the arm-none-eabi compiler (include trailing /!)
-        COMPILERPATH = /opt/homebrew/bin/
-        #COMPILERPATH = $(abspath $(TOOLSPATH))/arm/bin/
+        # Defaults to the newest Arm GNU Toolchain install; override with
+        # make COMPILERPATH=/path/to/arm-none-eabi/bin/
+        COMPILERPATH ?= $(lastword $(sort $(wildcard /Applications/ArmGNUToolchain/*)))/arm-none-eabi/bin/
     endif
     ifeq ($(UNAME_S),Linux)
         # path location for the arm-none-eabi compiler
-        COMPILERPATH =  # empty = on system path
+        COMPILERPATH ?=  # empty = on system path
     endif
 endif
 
@@ -54,10 +58,10 @@ LIBRARYPATH = $(CURDIR)/libraries
 #************************************************************************
 
 # CPPFLAGS = compiler options for C and C++
-CPPFLAGS = -Wall -g -O2 -mthumb -ffunction-sections -fdata-sections -nostdlib -MMD $(OPTIONS) -DTEENSYDUINO=124 -DF_CPU=$(TEENSY_CORE_SPEED) -Isrc -I../../ -I"$(FIRMWARE_PATH)" -I$(COREPATH)
+CPPFLAGS = -Wall -g -O2 -mthumb -ffunction-sections -fdata-sections -nostdlib -MMD $(OPTIONS) -DTEENSYDUINO=124 -DF_CPU=$(TEENSY_CORE_SPEED) -Isrc -I../../ -I"$(FIRMWARE_PATH)" -I"$(MIDI_LIB_PATH)" -I$(COREPATH)
 
 # compiler options for C++ only
-CXXFLAGS = -std=gnu++0x -felide-constructors -fno-exceptions -fno-rtti
+CXXFLAGS = -std=gnu++14 -felide-constructors -fno-exceptions -fno-rtti
 
 # compiler options for C only
 CFLAGS =
@@ -110,7 +114,7 @@ LCPP_FILES := $(wildcard $(LIBRARYPATH)/*/*.cpp) $(wildcard $(LIBRARYPATH)/*/*/*
 TC_FILES := $(wildcard $(COREPATH)/*.c)
 TCPP_FILES := $(wildcard $(COREPATH)/*.cpp)
 C_FILES := $(wildcard src/*.c) $(wildcard src/lib/*.c) $(wildcard $(FIRMWARE_PATH)/*.c)
-CPP_FILES := $(wildcard src/*.cpp) $(wildcard src/lib/*.cpp) $(wildcard $(FIRMWARE_PATH)/*.cpp)
+CPP_FILES := $(wildcard src/*.cpp) $(wildcard src/lib/*.cpp) $(wildcard $(FIRMWARE_PATH)/*.cpp) $(wildcard $(MIDI_LIB_PATH)/*.cpp)
 INO_FILES := $(wildcard src/*.ino) $(wildcard $(FIRMWARE_PATH)/*.ino)
 
 # include paths for libraries

--- a/brains1/src/Leds.h
+++ b/brains1/src/Leds.h
@@ -11,7 +11,6 @@
 #define LED_WHITE CRGB(230,255,150)
 
 #define leds(A) physical_leds[led_order[A]]
-#define next_step ((current_step+1)%SEQUENCER_NUM_STEPS)
 
 CRGB physical_leds[NUM_LEDS];
 #define led_play physical_leds[0]
@@ -98,40 +97,44 @@ void led_init() {
 
 // Updates the LED colour and brightness to match the stored sequence
 void led_update() {
-  for (int l = 0; l < SEQUENCER_NUM_STEPS; l++) {
-    if (step_enable[l]) {
-      leds(l) = COLORS[step_note[l]%24];
+  for (int l = 0; l < Sequencer::NUM_STEPS; l++) {
+    if (sequencer.get_step_enabled(l)) {
+      leds(l) = COLORS[sequencer.get_step_note(l)%24];
     } else {
       leds(l) = CRGB::Black;
     }
-     
-    if(note_is_playing) {
-      leds(((current_step+random_offset)%SEQUENCER_NUM_STEPS)) = LED_WHITE;
-    } else {
-      if(!step_enable[((current_step+random_offset)%SEQUENCER_NUM_STEPS)]) {
-        leds(((current_step+random_offset)%SEQUENCER_NUM_STEPS)) = CRGB::Black;
-      }
+  }
 
-      if(!sequencer_is_running) {
-        if(((sequencer_clock % 24) < 12)) {
-          if(step_enable[next_step]) {
-            leds(next_step) = COLORS[step_note[next_step]%24];
-          } else {
-            leds(next_step) = CRGB::Black;
-          }
-          led_play = LED_WHITE;
-          led_play.fadeLightBy((sequencer_clock % 12)*16);
-        } else {
-          led_play = CRGB::Black;
-          if(step_enable[next_step]) {
-            leds(next_step) = blend(LED_WHITE, COLORS[step_note[next_step]%24], (sequencer_clock % 12)*16);
-          } else {
-            leds(next_step) = LED_WHITE;
-            leds(next_step) = leds(next_step).fadeLightBy((sequencer_clock % 12)*16);
-          }
-        }
-      } else {
+  const auto cur_seq_step = sequencer.cur_step_index();
+
+  if (sequencer.gate_active()) {
+    leds(cur_seq_step) = LED_WHITE;
+  }
+
+  if (sequencer.is_running()) {
+    led_play = LED_WHITE;
+  } else {
+    if (sequencer.note_playing()) {
+      leds(Sequencer::wrapped_step(cur_seq_step)) = LED_WHITE;
+    } else {
+      const unsigned step_ticks = Sequencer::TICKS_PER_STEP;
+      const uint32_t seq_clock = sequencer.get_clock() + step_ticks;
+      const uint32_t fade_val = (seq_clock % step_ticks) * 16;
+      const bool fade_play = (seq_clock % (2 * step_ticks)) < step_ticks;
+
+      // Toggle between fading play button or current step.
+      if (fade_play) {
         led_play = LED_WHITE;
+        led_play.fadeLightBy(fade_val);
+      } else {
+        led_play = CRGB::Black;
+
+        if (sequencer.get_step_enabled(cur_seq_step)) {
+          leds(cur_seq_step) = blend(LED_WHITE, COLORS[sequencer.get_step_note(cur_seq_step)%24], fade_val);
+        } else {
+          leds(cur_seq_step) = LED_WHITE;
+          leds(cur_seq_step) = leds(cur_seq_step).fadeLightBy(fade_val);
+        }
       }
     }
   }

--- a/brains1/src/Power.h
+++ b/brains1/src/Power.h
@@ -39,7 +39,7 @@ bool power_check() {
 
 void power_off() {
   sequencer_stop();
-  MIDI.sendControlChange(123,0,MIDI_CHANNEL);
+  MIDI::sendControlChange(123,0,MIDI_CHANNEL);
   tempo_handler.reset_clock_source();
   transpose = 0;
   AudioNoInterrupts();
@@ -115,8 +115,8 @@ void power_on() {
   amp_disable();
   midi_clock = 0;
   in_setup = true;
-  // Clear note stack
-  note_stack.Clear();
+  // Clear held notes
+  sequencer.release_all_notes();
   // Read the MIDI channel from EEPROM. Lowest four bits
   uint8_t stored_midi_channel = eeprom_read_byte(EEPROM_MIDI_CHANNEL) & 0xf00;
   midi_set_channel(stored_midi_channel);

--- a/brains1/src/Synth.h
+++ b/brains1/src/Synth.h
@@ -198,10 +198,11 @@ void synth_update() {
   osc_pulse.pulseWidth(map(synth.pulseWidth,0,1023,1000,100)/1000.0);
 
   filter1.frequency((synth.filter/2)+30);
-  filter1.resonance(map(synth.resonance,0,1023,70,320)/100.0); // 0.7-3.2 range
+  float filter_resonance = map(synth.resonance,0,1023,70,320)/100.0f; // 0.7-3.2 range
   if(synth.accent) {
     filter_resonance = 4.0f;
   }
+  filter1.resonance(filter_resonance);
 
   envelope1.release(((synth.release*synth.release) >> 11)+30);
 

--- a/brains1/src/lib/midi_wrapper.cpp
+++ b/brains1/src/lib/midi_wrapper.cpp
@@ -1,0 +1,84 @@
+#include "midi_wrapper.h"
+#include "Arduino.h" // For HardwareSerial and usbMIDI
+#include <MIDI.h>
+
+// DIN MIDI is on Serial1 (pins 0/1)
+static MIDI_NAMESPACE::MidiInterface<HardwareSerial> serial_midi(Serial1);
+
+// The Teensy 3 core usbMIDI has no sysex or start/stop/continue handlers,
+// so those are dispatched by hand in read() and from the realtime callback.
+static MIDI::Callbacks usb_callbacks = {};
+
+static void usb_handle_realtime(uint8_t type) {
+  switch (type) {
+    case 0xF8: // Clock
+      if (usb_callbacks.clock) usb_callbacks.clock();
+      break;
+    case 0xFA: // Start
+      if (usb_callbacks.start) usb_callbacks.start();
+      break;
+    case 0xFB: // Continue
+      if (usb_callbacks.cont) usb_callbacks.cont();
+      break;
+    case 0xFC: // Stop
+      if (usb_callbacks.stop) usb_callbacks.stop();
+      break;
+  }
+}
+
+void MIDI::init(const Callbacks &callbacks) {
+  usb_callbacks = callbacks;
+
+  serial_midi.begin();
+  serial_midi.setHandleClock(callbacks.clock);
+  serial_midi.setHandleNoteOn(callbacks.note_on);
+  serial_midi.setHandleNoteOff(callbacks.note_off);
+  serial_midi.setHandleStart(callbacks.start);
+  serial_midi.setHandleStop(callbacks.stop);
+  serial_midi.setHandleContinue(callbacks.cont);
+  serial_midi.setHandleControlChange(callbacks.cc);
+  serial_midi.setHandleSystemExclusive(callbacks.sysex);
+
+  usbMIDI.setHandleNoteOn(callbacks.note_on);
+  usbMIDI.setHandleNoteOff(callbacks.note_off);
+  usbMIDI.setHandleControlChange(callbacks.cc);
+  usbMIDI.setHandleRealTimeSystem(usb_handle_realtime);
+}
+
+void MIDI::read(const byte channel) {
+  serial_midi.read(channel);
+  while (usbMIDI.read(channel)) {
+    // Sysex (type 7) has no handler in the old core; length is in data1
+    if (usbMIDI.getType() == 7 && usb_callbacks.sysex) {
+      usb_callbacks.sysex(usbMIDI.getSysExArray(), usbMIDI.getData1());
+    }
+  }
+}
+
+void MIDI::sendRealTime(const midi::MidiType message) {
+  serial_midi.sendRealTime(message);
+  usbMIDI.sendRealTime(message);
+}
+
+void MIDI::sendControlChange(const byte cc, const byte value,
+                             const byte channel) {
+  serial_midi.sendControlChange(cc, value, channel);
+  usbMIDI.sendControlChange(cc, value, channel);
+}
+
+void MIDI::sendNoteOn(const byte note, const byte velocity,
+                      const byte channel) {
+  serial_midi.sendNoteOn(note, velocity, channel);
+  usbMIDI.sendNoteOn(note, velocity, channel);
+}
+
+void MIDI::sendNoteOff(const byte note, const byte velocity,
+                       const byte channel) {
+  serial_midi.sendNoteOff(note, velocity, channel);
+  usbMIDI.sendNoteOff(note, velocity, channel);
+}
+
+void MIDI::sendSysEx(const unsigned length, const byte *bytes) {
+  serial_midi.sendSysEx(length, bytes);
+  usbMIDI.sendSysEx(length, bytes);
+}

--- a/brains1/src/lib/midi_wrapper.h
+++ b/brains1/src/lib/midi_wrapper.h
@@ -1,0 +1,31 @@
+#ifndef MIDI_H_Z6SY8IRY
+#define MIDI_H_Z6SY8IRY
+#include <midi_Defs.h>
+
+namespace MIDI {
+typedef void(VoidCallback)();
+typedef void(SyxCallback)(byte *data, unsigned length);
+typedef void(NoteCallback)(byte channel, byte note, byte velocity);
+
+struct Callbacks {
+  NoteCallback *note_on;
+  NoteCallback *note_off;
+  VoidCallback *clock;
+  VoidCallback *start;
+  VoidCallback *cont;
+  VoidCallback *stop;
+  NoteCallback *cc;
+  SyxCallback *sysex;
+};
+
+void init(const Callbacks &callbacks);
+void read(byte channel);
+void sendRealTime(midi::MidiType message);
+void sendControlChange(byte cc, byte value, byte channel);
+void sendNoteOn(byte inNoteNumber, byte inVelocity, byte inChannel);
+void sendNoteOff(byte inNoteNumber, byte inVelocity, byte inChannel);
+void sendSysEx(unsigned length, const byte *bytes);
+
+}; // namespace MIDI
+
+#endif /* end of include guard: MIDI_H_Z6SY8IRY */

--- a/brains1/src/pins_duo_1.0.h
+++ b/brains1/src/pins_duo_1.0.h
@@ -1,5 +1,5 @@
-#ifndef PINS_DUO_1.0_H
-#define PINS_DUO_1.0_H
+#ifndef PINS_DUO_1_0_H
+#define PINS_DUO_1_0_H
 
 #include <Arduino.h>
 #include <cstdint>
@@ -144,4 +144,4 @@ int potRead(uint8_t num);
 uint8_t muxDigitalRead(uint8_t channel);
 void pins_init();
 
-#endif /* end of include guard: PINS_DUO_1.0_H */
+#endif /* end of include guard: PINS_DUO_1_0_H */

--- a/brains1/src/src.ino
+++ b/brains1/src/src.ino
@@ -41,32 +41,20 @@ const uint8_t SCALE_OFFSET_FROM_C3[] { 1,3,6,8,10,13,15,18,20,22 };
 #define HIGH_SAMPLE_RATE 44100
 #define LOW_SAMPLE_RATE 2489
 
-#define INITIAL_VELOCITY 100
-
 #define EEPROM_MIDI_CHANNEL 0
 
 // Globals that should not be globals
-int gate_length_msec = 40;
-
-uint32_t sequencer_clock = 0;
-// Sequencer settings
-uint8_t current_step;
-uint8_t set_key = 9;
 float osc_saw_frequency = 0.;
 float osc_pulse_frequency = 0.;
 float osc_pulse_target_frequency = 0.;
 float osc_saw_target_frequency = 0.;
 uint8_t osc_pulse_midi_note = 0;
 uint8_t note_is_playing = 0;
-bool note_is_triggered = false;
 int transpose = 0;
-bool next_step_is_random = false;
-int tempo_interval;
 bool random_flag = 0;
 bool dfu_flag = 0;
 bool in_setup = true;
 
-int random_offset = 0;
 uint32_t midi_clock = 0;
 uint16_t audio_peak_values = 0UL;
 
@@ -79,7 +67,6 @@ void print_log();
 void note_on(uint8_t midi_note, uint8_t velocity, bool enabled);
 void note_off();
 
-void keyboard_to_note();
 float detune(int note, int amount);
 
 int tempo_interval_msec();
@@ -89,27 +76,35 @@ void enter_dfu();
 #include "synth_params.h"
 synth_parameters synth;
 
-#include "note_stack.h"
-NoteStack<10> note_stack;
-
 #include "pinmap.h"
+#include "lib/midi_wrapper.h"
 
-#define MIDI_SYSEX_DATA_TYPE const uint8_t
+void sequencer_note_on(uint8_t midi_note, uint8_t velocity) {
+  note_on(midi_note + transpose, velocity, true);
+}
+#include "seq.h"
+
+void sequencer_randomize_step_offset(Sequencer::Sequencer &seq) {
+  const uint8_t offset =
+      seq.get_step_offset() + random(1, (Sequencer::NUM_STEPS - 2));
+  seq.set_step_offset(offset);
+}
+
+void sequencer_on_running_advance(Sequencer::Sequencer &seq) {
+  if (random_flag) {
+    sequencer_randomize_step_offset(seq);
+  } else {
+    seq.set_step_offset(0);
+  }
+}
+
+Sequencer::Sequencer
+    sequencer(Sequencer::Output::Callbacks{.note_on = sequencer_note_on,
+                                           .note_off = note_off},
+              sequencer_on_running_advance);
+
+#define MIDI_SYSEX_DATA_TYPE byte
 #include "MidiFunctions.h"
-
-void midi_usb_sysex_callback(MIDI_SYSEX_DATA_TYPE *data, uint16_t length, bool complete){
-  midi_usb_sysex(data, length);
-}
-
-void PlatformMidi::init(){
-  usbMIDI.setHandleSysEx(midi_usb_sysex_callback);
-  usbMIDI.setHandleRealTimeSystem(midi_handle_realtime);
-}
-
-void midi_send_realtime(const midi::MidiType message){
-    MIDI.sendRealTime(message);
-    usbMIDI.sendRealTime(message);
-}
 
 void midi_set_channel(uint8_t channel) {
   if(channel > 0 && channel <= 16) {
@@ -127,9 +122,26 @@ uint8_t midi_get_channel() {
 
 
 #include "TempoHandler.h"
-TempoHandler tempo_handler(synth);
+TempoHandler tempo_handler;
 
 #include "Sequencer.h"
+
+void midi_handle_clock() {
+  tempo_handler.midi_clock_received();
+  midi_clock++;
+}
+
+void midi_init() {
+  MIDI::init(MIDI::Callbacks{.note_on = midi_note_on,
+                             .note_off = midi_note_off,
+                             .clock = midi_handle_clock,
+                             .start = sequencer_start_from_MIDI,
+                             .cont = sequencer_start_from_MIDI,
+                             .stop = sequencer_stop,
+                             .cc = midi_handle_cc,
+                             .sysex = midi_handle_sysex});
+}
+
 #include "Leds.h"
 #include "DrumSynth.h"
 #include "Pitch.h"
@@ -164,12 +176,6 @@ void setup() {
   drum_init();
   touch_init();
 
-  MIDI.setHandleStart(sequencer_restart);
-  MIDI.setHandleContinue(sequencer_restart);
-  MIDI.setHandleStop(sequencer_stop);
-
-  previous_note_on_time = millis();
-
   #ifdef DEV_MODE
     Serial.begin(57600);
     Serial.print("Dato DUO firmware ");
@@ -198,7 +204,7 @@ void loop() {
     #ifdef DEV_MODE
       GPIOA_PSOR |= (1<<1); // Toggle benchmark pin
     #endif
-    midi_handle();
+    MIDI::read(MIDI_CHANNEL);
     sequencer_update();
     #ifdef DEV_MODE
       GPIOA_PCOR |= (1<<1); // Toggle benchmark pin
@@ -206,8 +212,7 @@ void loop() {
 
     // Crude hard coded task switching
     keys_scan(); // 14 or 175us (depending on debounce)
-    keyboard_to_note();  
-    pitch_update();  // ~30us 
+    pitch_update();  // ~30us
     pots_read(); // ~ 100us
 
     synth_update(); // ~ 100us
@@ -218,7 +223,7 @@ void loop() {
     #ifdef DEV_MODE
       GPIOA_PSOR |= (1<<1); // Toggle benchmark pin
     #endif
-    midi_handle();
+    MIDI::read(MIDI_CHANNEL);
     sequencer_update();
     #ifdef DEV_MODE
       GPIOA_PCOR |= (1<<1); // Toggle benchmark pin
@@ -232,32 +237,6 @@ void loop() {
       led_update(); // ~ 2ms
     }
   }
-}
-
-void midi_handle_clock() {
-  tempo_handler.midi_clock_received();
-  midi_clock++;
-}
-
-void midi_handle_realtime(uint8_t type) {
-  switch(type) {
-      case 0xF8: // Clock
-        midi_handle_clock();
-        break;
-      case 0xFA: // Start
-        sequencer_reset_clock();
-        sequencer_start();
-        break;
-      case 0xFC: // Stop
-        sequencer_stop();
-        break;
-      case 0xFB: // Continue
-        sequencer_start();
-        break;
-      case 0xFE: // ActiveSensing
-      case 0xFF: // SystemReset
-        break;
-    }
 }
 
 // Scans the button_matrix and handles step enable and keys
@@ -288,12 +267,13 @@ void keys_scan() {
                     keyboard_set_note(SCALE[k - KEYB_0]);
                   }
                 } else if (k <= STEP_8 && k >= STEP_1) {
-                  step_enable[k-STEP_1] = 1-step_enable[k-STEP_1];
-                  if(!step_enable[k-STEP_1]) { leds(k-STEP_1) = CRGB::Black; }
-                  step_velocity[k-STEP_1] = INITIAL_VELOCITY;
+                  const uint8_t step = k - STEP_1;
+                  if(!sequencer.toggle_step(step)) {
+                    leds(step) = CRGB::Black;
+                  }
                 } else if (k == BTN_SEQ2) {
-                  if(!sequencer_is_running) {
-                    sequencer_advance();
+                  if(!sequencer.is_running()) {
+                    sequencer.advance();
                   }
                   double_speed = true;
                 } else if (k == BTN_DOWN) {
@@ -303,11 +283,11 @@ void keys_scan() {
                   transpose++;
                   if(transpose>12){transpose = 24;}
                 } else if (k == BTN_SEQ1) {
-                  next_step_is_random = true;
-                  if(!sequencer_is_running) {
-                    sequencer_advance();
+                  if(sequencer.is_running()) {
+                    random_flag = true;
+                  } else {
+                    sequencer_randomize_step_offset(sequencer);
                   }
-                  random_flag = true;
                 } else if (k == SEQ_START) {
                   sequencer_toggle_start();
                 }
@@ -346,7 +326,6 @@ void keys_scan() {
                   if(transpose<-12){transpose = -12;}
                   if(transpose>12){transpose = 12;}
                 } else if (k == BTN_SEQ1) {
-                  next_step_is_random = false;
                   random_flag = false;
                 } else if (k == SEQ_START) {
                   #ifdef DEV_MODE
@@ -369,7 +348,7 @@ void keys_scan() {
 
 void pots_read() {
   synth.speed = potRead(TEMPO_POT);
-  synth.gateLength = map(potRead(GATE_POT),0,1023,10,200);
+  synth.gateLength = potRead(GATE_POT);
   
   synth.detune = potRead(OSC_DETUNE_POT);
   synth.release = potRead(AMP_ENV_POT);
@@ -400,28 +379,21 @@ void note_on(uint8_t midi_note, uint8_t velocity, bool enabled) {
 
     AudioInterrupts(); 
 
-    MIDI.sendNoteOn(midi_note, velocity, MIDI_CHANNEL);
-    usbMIDI.sendNoteOn(midi_note, velocity, MIDI_CHANNEL);
+    MIDI::sendNoteOn(midi_note, velocity, MIDI_CHANNEL);
     envelope1.noteOn();
     envelope2.noteOn();
   } else {
-    leds((current_step+random_offset)%SEQUENCER_NUM_STEPS) = LED_WHITE;
-
+    leds(sequencer.cur_step_index() % Sequencer::NUM_STEPS) = LED_WHITE;
   }
 }
 
 void note_off() {
   if (note_is_playing) {
-    MIDI.sendNoteOff(note_is_playing, 0, MIDI_CHANNEL);
-    usbMIDI.sendNoteOff(note_is_playing, 0, MIDI_CHANNEL);
-    if(!step_enable[current_step]) {
-      leds(current_step) = CRGB::Black;
-    } else {
-      envelope1.noteOff();
-      envelope2.noteOff();
-    }
+    MIDI::sendNoteOff(note_is_playing, 0, MIDI_CHANNEL);
+    envelope1.noteOff();
+    envelope2.noteOff();
     note_is_playing = 0;
-  } 
+  }
 }
 
 /*


### PR DESCRIPTION
## Summary

The Brains 1 (Teensy 3.1) build had bit-rotted since the shared code restructure in 683f9b7 (Feb 2024) — `src.ino` still targeted the pre-2024 shared API and there was no Brains 1 `midi_wrapper`. This ports it to the current shared code, modeled on how `brains2/apps/duo/main.cpp` consumes it:

- **New `brains1/src/lib/midi_wrapper.{h,cpp}`** — implements the `MIDI::` namespace API over the Arduino MIDI 4.x library on `Serial1` (DIN MIDI) plus the Teensy 3 core `usbMIDI`. The old core has no usb sysex/start/stop handlers, so sysex is polled in `MIDI::read()` and transport messages are dispatched from the realtime callback.
- **`src.ino`** — `Sequencer::Sequencer` object with callbacks replaces the old `step_enable[]`/`sequencer_advance()` globals; `MIDI::init(Callbacks{...})` replaces the `PlatformMidi`/direct `usbMIDI` wiring; default-constructed `TempoHandler`; `gateLength` stores the raw pot value (the shared `sequencer_update()` does the mapping — it was previously mapped twice).
- **`Leds.h`** — `led_update()` ported to the sequencer API, keeping the Brains 1 `analogWrite` panel LEDs.
- **`Power.h` / `Synth.h`** — wrapper-API calls; fixed `filter_resonance` (undeclared identifier).
- **`Makefile`** — `FIRMWARE_PATH` → `../shared/duo`, auto-detected overridable `COMPILERPATH`, MIDI library built from `brains2/libraries/MIDI`, `-std=gnu++14`. Also fixed the invalid `PINS_DUO_1.0_H` include guard.

`BRAINS1_BUILD.md` documents the build and the changes.

## Testing

- `make clean && make -j8` builds `brains1.hex`/`brains1.bin` cleanly with Arm GNU Toolchain 14.2 (55 KB text, fits MK20DX256).
- **Not yet tested on hardware** — the Serial1 DIN MIDI and usbMIDI sysex paths deserve a bench check.
- brains1 is still absent from CI.